### PR TITLE
244242: Changes to enable Flux to connect to private ACR

### DIFF
--- a/.azuredevops/deploy-platform-core.yaml
+++ b/.azuredevops/deploy-platform-core.yaml
@@ -189,6 +189,7 @@ extends:
             ${{ if eq(variables.IsAll, true) }}:
               dependsOnGroupedTemplates:
                 - network
+                - application_infra
             templates:
               - ${{ if eq(variables.IsManagedClusterPrivateDNSZone, true) }}:
                 - name: aks-cluster-zone

--- a/infra/core/managed-cluster/aks-cluster.bicep
+++ b/infra/core/managed-cluster/aks-cluster.bicep
@@ -221,6 +221,8 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.3
         'notification-controller.enabled': 'true'
         'image-automation-controller.enabled': 'true'
         'image-reflector-controller.enabled': 'true'
+        'helm-controller.detectDrift': 'true'
+        'useKubeletIdentity': 'true'
       }
       configurations: [
         {
@@ -243,6 +245,7 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.3
               syncIntervalInSeconds: fluxConfig.clusterCore.kustomizations.syncIntervalInSeconds
               validation: 'none'
               prune: true
+              postBuild: fluxConfig.clusterCore.kustomizations.postBuild
             }
             infra: {
               path: fluxConfig.clusterCore.kustomizations.infraPath
@@ -253,6 +256,7 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.3
               ]
               validation: 'none'
               prune: true
+              postBuild: fluxConfig.clusterCore.kustomizations.postBuild
             }
             services: {
               path: fluxConfig.clusterCore.kustomizations.servicesPath
@@ -264,6 +268,7 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.3
               ]
               validation: 'none'
               prune: true
+              postBuild: fluxConfig.clusterCore.kustomizations.postBuild
             }
           } 
         } 

--- a/infra/core/managed-cluster/aks-cluster.parameters.json
+++ b/infra/core/managed-cluster/aks-cluster.parameters.json
@@ -99,9 +99,9 @@
                 "INFRA_RG": "#{{ servicesResourceGroup }}",
                 "TEAM_MI_NAME": "#{{ infraResourceNamePrefix }}#{{ nc_resource_managedidentity }}#{{ nc_instance_regionid }}01",
                 "CLUSTER_OIDC": "",
-                "TENANT_ID": "#{{ subscriptionName }}",
+                "TENANT_ID": "#{{ tenantId }}",
                 "SUBSCRIPTION_ID": "#{{ subscriptionId }}",
-                "SUBSCRIPTION_NAME": "#{{ tenantId }}"
+                "SUBSCRIPTION_NAME": "#{{ subscriptionName }}"
               }
             }
           }

--- a/infra/core/managed-cluster/aks-cluster.parameters.json
+++ b/infra/core/managed-cluster/aks-cluster.parameters.json
@@ -55,9 +55,9 @@
     },
     "containerRegistry": {
       "value": {
-        "name": "#{{ ssvSharedAcrName }}",
-        "resourceGroup": "#{{ ssvSharedResourceGroup }}",
-        "subscriptionId": "#{{ ssv3subscriptionId }}"
+        "name": "#{{ infraResourceNamePrefix }}#{{ nc_resource_containerregistry }}#{{ nc_instance_regionid }}01",
+        "resourceGroup": "#{{ servicesResourceGroup }}",
+        "subscriptionId": "#{{ subscriptionId }}"
       }
     },
     "location": {
@@ -84,9 +84,26 @@
           "kustomizations": {
             "timeoutInSeconds": 600,
             "syncIntervalInSeconds": 600,
-            "clusterPath": "./clusters/#{{ lower(environment) }}/01",
-            "infraPath": "./infra/#{{ lower(environment) }}/01",
-            "servicesPath": "./services/#{{ lower(environment) }}/01"
+            "clusterPath": "./clusters/#{{ lower(environment) }}/0#{{ environmentId }}",
+            "infraPath": "./infra/#{{ lower(environment) }}/0#{{ environmentId }}",
+            "servicesPath": "./services/#{{ lower(environment) }}/0#{{ environmentId }}",
+            "postBuild": {
+              "substitute": {
+                "ENVIRONMENT": "#{{ lower(environment) }}",
+                "ACR_NAME": "#{{ infraResourceNamePrefix }}#{{ nc_resource_containerregistry }}#{{ nc_instance_regionid }}01",
+                "CLUSTER": "0#{{ environmentId }}",
+                "SERVICEBUS_RG": "#{{ servicesResourceGroup }}",
+                "SERVICEBUS_NS": "#{{ infraResourceNamePrefix }}#{{ nc_resource_servicebus }}#{{ nc_instance_regionid }}01",
+                "POSTGRES_SERVER_RG": "#{{ dbsResourceGroup }}",
+                "POSTGRES_SERVER": "#{{ dbsResourceNamePrefix }}#{{ nc_resource_postgresql }}#{{ nc_instance_regionid }}01",
+                "INFRA_RG": "#{{ servicesResourceGroup }}",
+                "TEAM_MI_NAME": "#{{ infraResourceNamePrefix }}#{{ nc_resource_managedidentity }}#{{ nc_instance_regionid }}01",
+                "CLUSTER_OIDC": "",
+                "TENANT_ID": "#{{ subscriptionName }}",
+                "SUBSCRIPTION_ID": "#{{ subscriptionId }}",
+                "SUBSCRIPTION_NAME": "#{{ tenantId }}"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
- Added a Postbuild to the Flux Configuration parameters to set variables required by the Flux Kustomizations. These will in future be replaced with Config Maps created as part of the AKS Cluster deployment.
- The SSV5 ACR has anonymous pull, so RBAC is no longer required. I have changed this to instead grant RBAC to the application specific ACR. I have almost modified the pipeline YAML to ensure the AKS Cluster is deployed only after the application ACR has been created.

*Link to the relevant work items: e.g. [AB#244242](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/244242)