### PR TITLE
252376: Move flux extension out of AKS deployment

### DIFF
--- a/infra/core/managed-cluster/.bicep/app-config-data-reader.bicep
+++ b/infra/core/managed-cluster/.bicep/app-config-data-reader.bicep
@@ -1,0 +1,18 @@
+@description('Required. The parameter object for the managed identity. The object must contain the name and principalId values.')
+param principalId string
+@description('Required. The name of the app configuration service.')
+param appConfigName string
+
+resource appconfig 'Microsoft.AppConfiguration/configurationStores@2023-03-01' existing = {
+  name: appConfigName
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, principalId, 'appConfigurationDataReader')
+  scope: appconfig
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '516239f1-63e1-4d78-a4de-a74fb236a071') // App Configuration Data Reader
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infra/core/managed-cluster/.bicep/app-config-data-reader.bicep
+++ b/infra/core/managed-cluster/.bicep/app-config-data-reader.bicep
@@ -1,4 +1,4 @@
-@description('Required. The parameter object for the managed identity. The object must contain the name and principalId values.')
+@description('Required. The principal id for the managed identity.')
 param principalId string
 @description('Required. The name of the app configuration service.')
 param appConfigName string

--- a/infra/core/managed-cluster/aks-cluster.bicep
+++ b/infra/core/managed-cluster/aks-cluster.bicep
@@ -379,7 +379,7 @@ module acrPullRoleAssignment '.bicep/acr-pull.bicep' = {
 
 module appConfigurationDataReaderRoleAssignment '.bicep/app-config-data-reader.bicep' = {
   name: 'app-config-data-reader-role-assignment-${deploymentDate}'
-  scope: resourceGroup(appConfig.name)
+  scope: resourceGroup(appConfig.resourceGroup)
   dependsOn: [
     deployAKS
   ]

--- a/infra/core/managed-cluster/aks-cluster.bicep
+++ b/infra/core/managed-cluster/aks-cluster.bicep
@@ -299,6 +299,7 @@ module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.ex
     name: 'flux'
     location: location
     releaseTrain: 'Stable'
+    releaseNamespace: 'flux-system'
     configurationSettings: {
       'helm-controller.enabled': 'true'
       'source-controller.enabled': 'true'

--- a/infra/core/managed-cluster/aks-cluster.parameters.json
+++ b/infra/core/managed-cluster/aks-cluster.parameters.json
@@ -86,30 +86,20 @@
             "syncIntervalInSeconds": 600,
             "clusterPath": "./clusters/#{{ lower(environment) }}/0#{{ environmentId }}",
             "infraPath": "./infra/#{{ lower(environment) }}/0#{{ environmentId }}",
-            "servicesPath": "./services/#{{ lower(environment) }}/0#{{ environmentId }}",
-            "postBuild": {
-              "substitute": {
-                "ENVIRONMENT": "#{{ lower(environment) }}",
-                "ACR_NAME": "#{{ infraResourceNamePrefix }}#{{ nc_resource_containerregistry }}#{{ nc_instance_regionid }}01",
-                "CLUSTER": "0#{{ environmentId }}",
-                "SERVICEBUS_RG": "#{{ servicesResourceGroup }}",
-                "SERVICEBUS_NS": "#{{ infraResourceNamePrefix }}#{{ nc_resource_servicebus }}#{{ nc_instance_regionid }}01",
-                "POSTGRES_SERVER_RG": "#{{ dbsResourceGroup }}",
-                "POSTGRES_SERVER": "#{{ dbsResourceNamePrefix }}#{{ nc_resource_postgresql }}#{{ nc_instance_regionid }}01",
-                "INFRA_RG": "#{{ servicesResourceGroup }}",
-                "TEAM_MI_NAME": "#{{ infraResourceNamePrefix }}#{{ nc_resource_managedidentity }}#{{ nc_instance_regionid }}01",
-                "CLUSTER_OIDC": "",
-                "TENANT_ID": "#{{ tenantId }}",
-                "SUBSCRIPTION_ID": "#{{ subscriptionId }}",
-                "SUBSCRIPTION_NAME": "#{{ subscriptionName }}"
-              }
-            }
+            "servicesPath": "./services/#{{ lower(environment) }}/0#{{ environmentId }}"
           }
         }
       }
     },
     "asoPlatformManagedIdentity": {
       "value": "#{{ infraResourceNamePrefix }}#{{ nc_resource_managedidentity }}#{{ nc_instance_regionid }}01-adp-aso-platform"
+    },
+    "appConfig": {
+      "value": {
+        "name": "#{{ infraResourceNamePrefix }}#{{ nc_resource_appconfiguration }}#{{ nc_instance_regionid }}01",
+        "resourceGroup": "#{{ servicesResourceGroup }}",
+        "managedIdentityName": "#{{ infraResourceNamePrefix }}#{{ nc_resource_managedidentity }}#{{ nc_instance_regionid }}01-adp-ac-platform"
+      }
     }
   }
 }


### PR DESCRIPTION
We are moving the FluxExtension out of the Cluster deployment to allow us to create a managed identity for app config service after the Cluster deployment.  The Managed Identity requires the cluster_oidc url for Federated Credentials, which can only be obtained after Cluster creation.  The Managed Identity clientId then needs to be passed to the Flux Extension as a postbuild substitute variable.  This will then enable us to create configmaps and secrets using the AzureAppConfigurationProvider.

In addition to the above:
- Created managed identity and federated credential for App Config Service
- Granted App Config Data Reader to the managed identity on the App Config Service
- Remove postbuild substitute variables from parameters file as these will be created via the AzureAppConfigurationProvider
- Pass the app config name and app config mi clientId as postbuild substitution variables.

[AB#252376](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/252376)

Tested in isolated cluster 

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
