### PR TITLE
Pass variables required by ASO platform secret

### DIFF
--- a/infra/core/managed-cluster/aks-cluster.bicep
+++ b/infra/core/managed-cluster/aks-cluster.bicep
@@ -345,6 +345,9 @@ module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.ex
               substitute: {
                 APPCONFIG_NAME: appConfig.name
                 APPCONFIG_MI_CLIENTID: managedIdentityAppConfig.outputs.clientId
+                ASO_MI_CLIENTID: managedIdentityAso.outputs.clientId
+                SUBSCRIPTION_ID: subscription().subscriptionId
+                TENANT_ID: tenant().tenantId
               }
             }
           }


### PR DESCRIPTION
# **Description**
The ASO Platform secret values were initially hard-coded to get us moving.  The PR will pass in the required values as postbuild substitution variables.  

The required values are:

- The Platform Team ASO managed identity clientId
- subsciptionId
- tenantId

It made sense to do it this way as these values are available to us in the Bicep template to pass as postbuild substitution variables.  This keeps the solution to not using the hard-code variables simple.

[AB#250536](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/250536)

# **Special notes for your reviewer**
Discussed solution with Ajay and we both agreed it made sense to do it this way.

# Testing
Tested in isolated cluster.  Please see screenshot of values coming through on AKS in the Kustomization.

![image](https://github.com/DEFRA/adp-infrastructure-core/assets/39670555/5bc575c7-c576-490f-8177-33bd04745e32)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

