### PR TITLE
255576: Align flux-config name change as per adp-flux-core and ad-flux-services

### DIFF
--- a/infra/core/managed-cluster/aks-cluster.bicep
+++ b/infra/core/managed-cluster/aks-cluster.bicep
@@ -312,8 +312,8 @@ module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.ex
     }
     fluxConfigurations: [
       {
-        name: 'config-cluster-flux'
-        namespace: 'config-cluster-flux'
+        name: 'flux-config'
+        namespace: 'flux-config'
         scope: 'cluster'
         gitRepository: {
           repositoryRef: {


### PR DESCRIPTION
This change is to align the name change of config-cluster-flux to flux-config.  The change has already been made in adp-flux-core.

[AB#255576](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/255576) 

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
