### PR TITLE
275548: Add flux dash boards to grafana

### DIFF
--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -195,6 +195,16 @@ extends:
                         -ResourceGroupName $(ssvSharedResourceGroup)
                         -GrafanaName $(ssvResourceNamePrefix)$(nc_resource_grafana)$(nc_shared_instance_regionid)01
                         -WorkspaceResourceId '/subscriptions/$(subscriptionId)/resourceGroups/$(servicesResourceGroup)/providers/Microsoft.Monitor/accounts/$(infraResourceNamePrefix)$(nc_resource_azuremonitorworkspace)$(nc_instance_regionid)01'
+                  postDeployScriptsList:
+                    - displayName: Create Flux Dashboards in Grafana
+                      scriptPath: infra/core/env/scripts/New-FluxDashboards.ps1
+                      type: AzureCLI
+                      azureCLIScriptType: pscore
+                      serviceConnectionVariableName: ssvServiceConnection
+                      scriptArguments: >
+                        -ResourceGroupName $(ssvSharedResourceGroup)
+                        -GrafanaName $(ssvResourceNamePrefix)$(nc_resource_grafana)$(nc_shared_instance_regionid)01
+                        -DashboardsPath 'infra/core/env/observability/dashboards'
 
         - ${{ if eq(variables.IsPlatformKeyVault, true) }}:
           - name: platform

--- a/infra/core/env/managed-cluster/.bicep/prometheus-logs-requisite-resources.bicep
+++ b/infra/core/env/managed-cluster/.bicep/prometheus-logs-requisite-resources.bicep
@@ -51,3 +51,12 @@ module monitorWorkspaceRoleAssignment 'monitoring-data-reader.bicep' = {
     principalId: managedGrafana.identity.principalId
   }
 }
+
+module grafanaReaderSubscriptionRoleAssignment 'subscription-rbac.bicep' = {
+  name: 'reader-role-${deploymentDate}'
+  scope: subscription(subscription().subscriptionId)
+  params: {
+    principalId: managedGrafana.identity.principalId
+    roleDefinitionId: 'acdd72a7-3385-48ef-bd42-f606fba81ae7' // Reader
+  }
+}

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -89,7 +89,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'aa/fluxGrafanaDashBoard'
+      branch: 'main'
     }
     kustomizations: {
       timeoutInSeconds: 600

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -89,7 +89,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'main'
+      branch: 'aa/fluxGrafanaDashBoard'
     }
     kustomizations: {
       timeoutInSeconds: 600

--- a/infra/core/env/observability/dashboards/flux-application-deployments.json
+++ b/infra/core/env/observability/dashboards/flux-application-deployments.json
@@ -1,0 +1,811 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_FLUX_GITOPS",
+      "label": "Flux GitOps",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-azure-monitor-datasource",
+      "pluginName": "Azure Monitor"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.5.6"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-azure-monitor-datasource",
+      "name": "Azure Monitor",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${DS_FLUX_GITOPS}"
+      },
+      "description": "This table shows the list of clusters where Flux extension is deployed along with their current deployment status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "links"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ClusterName"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Extensions Page",
+                    "url": "https://portal.azure.com/#resource/subscriptions/${__data.fields.SubscriptionID}/resourceGroups/${__data.fields.ResourceGroup}/providers/${__data.fields.ClusterType}/${__data.fields.ClusterName}/extensions"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 229
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SubscriptionID"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ResourceGroup"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ClusterType"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Version"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 234
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ProvisioningState"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 218
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.5.6",
+      "targets": [
+        {
+          "azureMonitor": {
+            "allowedTimeGrainsMs": [],
+            "timeGrain": "auto"
+          },
+          "azureResourceGraph": {
+            "query": "kubernetesconfigurationresources\r\n| where type == \"microsoft.kubernetesconfiguration/extensions\"\r\n| extend ResourceGroup=tostring(resourceGroup)\r\n| where ResourceGroup in~ ($ResourceGroups)\r\n| where properties.ExtensionType =~ \"microsoft.flux\"\r\n| parse id with * \"ManagedClusters/\" aksClusterName \"/\" * \r\n| parse id with * \"ConnectedClusters/\" arcClusterName \"/\" *\r\n| extend clusterName = iff(isempty(aksClusterName), arcClusterName, aksClusterName)\r\n| extend clusterType = iff(isempty(aksClusterName), \"Microsoft.Kubernetes/connectedClusters\", \"Microsoft.ContainerService/managedClusters\")\r\n| extend provisioningState = tostring(properties.ProvisioningState)\r\n| extend statuses = iff(provisioningState == \"Failed\", properties[\"Statuses\"][0][\"Message\"], iff(provisioningState == \"Succeeded\", \"Successfully installed the extension\", iff(provisioningState == \"Deleting\", \"Deleting the extension\",\"Creating the extension\")))\r\n| project SubscriptionID=tostring(subscriptionId), ResourceGroup, ClusterType=clusterType, ClusterName=tostring(clusterName), Version=tostring(properties.Version), ProvisioningState=provisioningState, StatusMsg =tostring(statuses)"
+          },
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${DS_FLUX_GITOPS}"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$Subscriptions"
+          ]
+        }
+      ],
+      "title": "Flux Extension Deployments State",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${DS_FLUX_GITOPS}"
+      },
+      "description": "This table shows the list of Flux configurations created on the clusters along with their compliance status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "links"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SubscriptionID"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ResourceGroup"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ClusterType"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ClusterName"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "GitOps List Page",
+                    "url": "https://portal.azure.com/#resource/subscriptions/${__data.fields.SubscriptionID}/resourceGroups/${__data.fields.ResourceGroup}/providers/${__data.fields.ClusterType}/${__data.fields.ClusterName}/gitOps"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Configuration"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "GitOps Config Overview Page",
+                    "url": "https://portal.azure.com/#resource/subscriptions/${__data.fields.SubscriptionID}/resourceGroups/${__data.fields.ResourceGroup}/providers/${__data.fields.ClusterType}/${__data.fields.ClusterName}/providers/Microsoft.KubernetesConfiguration/fluxConfigurations/${__data.fields.Configuration}/overview"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ComplianceState"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Configuration Objects",
+                    "url": "https://portal.azure.com/#resource/subscriptions/${__data.fields.SubscriptionID}/resourceGroups/${__data.fields.ResourceGroup}/providers/${__data.fields.ClusterType}/${__data.fields.ClusterName}/providers/Microsoft.KubernetesConfiguration/fluxConfigurations/${__data.fields.Configuration}/configurationObjects"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "9.5.6",
+      "targets": [
+        {
+          "azureMonitor": {
+            "allowedTimeGrainsMs": [],
+            "timeGrain": "auto"
+          },
+          "azureResourceGraph": {
+            "query": "kubernetesconfigurationresources\r\n| where type == \"microsoft.kubernetesconfiguration/fluxconfigurations\"\r\n| extend ResourceGroup=tostring(resourceGroup)\r\n| where ResourceGroup in~ ($ResourceGroups)\r\n| parse id with * \"ManagedClusters/\" aksClusterName \"/\" * \r\n| parse id with * \"ConnectedClusters/\" arcClusterName \"/\" *\r\n| extend clusterName = iff(isempty(aksClusterName), arcClusterName, aksClusterName)\r\n| extend clusterType = iff(isempty(aksClusterName), \"Microsoft.Kubernetes/connectedClusters\", \"Microsoft.ContainerService/managedClusters\")\r\n| extend url = iff(properties.sourceKind =~ \"GitRepository\", tostring(properties.gitRepository.url), iff(properties.sourceKind =~ \"AzureBlob\", tostring(properties.azureBlob.url), tostring(properties.bucket.url)))\r\n| project SubscriptionID=tostring(subscriptionId), ResourceGroup, ClusterName=tostring(clusterName), ClusterType=clusterType, Configuration=tostring(name), SourceKind=tostring(properties.sourceKind), RepositoryURL=url, SourceLastSyncCommit=tostring(properties.sourceSyncedCommitId), ComplianceState=tostring(properties.complianceState)\r\n| order by ResourceGroup, ClusterName"
+          },
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${DS_FLUX_GITOPS}"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$Subscriptions"
+          ]
+        }
+      ],
+      "title": "Flux Configuration Compliance Status",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${DS_FLUX_GITOPS}"
+      },
+      "description": "A pie chart representing the count of clusters based on provisioning state.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Creating"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Deleting"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DeletingIdentity"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 8,
+      "options": {
+        "displayLabels": [
+          "value"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": []
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "azureMonitor": {
+            "allowedTimeGrainsMs": [],
+            "timeGrain": "auto"
+          },
+          "azureResourceGraph": {
+            "query": "kubernetesconfigurationresources\r\n| where type == \"microsoft.kubernetesconfiguration/extensions\"\r\n| extend ResourceGroup=tostring(resourceGroup)\r\n| where ResourceGroup in~ ($ResourceGroups)\r\n| where properties.ExtensionType =~ \"microsoft.flux\"\r\n| extend provisioningState = tostring(properties.ProvisioningState)\r\n| summarize Count=count() by provisioningState"
+          },
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${DS_FLUX_GITOPS}"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$Subscriptions"
+          ]
+        }
+      ],
+      "title": "Count of Flux Extension Deployments by Status",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${DS_FLUX_GITOPS}"
+      },
+      "description": "A pie chart representing the count of Flux configurations split by their compliance status with respect to the source repository.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Non-Compliant"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Compliant"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Suspended"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pending"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 6,
+      "options": {
+        "displayLabels": [
+          "value"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": []
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "azureMonitor": {
+            "allowedTimeGrainsMs": [],
+            "timeGrain": "auto"
+          },
+          "azureResourceGraph": {
+            "query": "kubernetesconfigurationresources\r\n| where type == \"microsoft.kubernetesconfiguration/fluxconfigurations\"\r\n| extend ResourceGroup=tostring(resourceGroup)\r\n| where ResourceGroup in~ ($ResourceGroups)\r\n| extend complianceState=iff(isnull(properties.complianceState), \"Pending\", tostring(properties.complianceState))\r\n| summarize Count=count() by complianceState"
+          },
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${DS_FLUX_GITOPS}"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$Subscriptions"
+          ]
+        }
+      ],
+      "title": "Count of Flux Configurations by Compliance Status",
+      "type": "piechart"
+    }
+  ],
+  "refresh": "",
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Flux GitOps",
+          "value": "Flux GitOps"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Azure Monitor Data Source",
+        "multi": false,
+        "name": "GitOpsDataSource",
+        "options": [],
+        "query": "grafana-azure-monitor-datasource",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${DS_FLUX_GITOPS}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Subscriptions",
+        "multi": true,
+        "name": "Subscriptions",
+        "options": [],
+        "query": {
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "queryType": "Azure Subscriptions",
+          "refId": "A"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${DS_FLUX_GITOPS}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Resource Groups",
+        "multi": true,
+        "name": "ResourceGroups",
+        "options": [],
+        "query": {
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "azureResourceGraph": {
+            "query": "kubernetesconfigurationresources\r\n| where type == \"microsoft.kubernetesconfiguration/extensions\"\r\n| distinct resourceGroup"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$Subscriptions"
+          ]
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "GitOps Flux - Application Deployments Dashboard",
+  "uid": "gitops-application-deployments",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/core/env/observability/dashboards/flux-cluster-stats.json
+++ b/infra/core/env/observability/dashboards/flux-cluster-stats.json
@@ -1,0 +1,1084 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
+          "iconColor": "red",
+          "name": "flux events",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [
+              "flux"
+            ],
+            "type": "tags"
+          }
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 100
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
+        "id": 24,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "last"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value"
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "count by(cluster) (gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"True\", kind=~\"Kustomization|HelmRelease\", cluster=~\"$selected_cluster\"}) - sum by(cluster) (gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"Deleted\", kind=~\"Kustomization|HelmRelease\", cluster=~\"$selected_cluster\"})",
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Cluster Reconcilers",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 6,
+          "y": 0
+        },
+        "id": 28,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "last"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value"
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "sum by(cluster) (gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"False\", kind=~\"Kustomization|HelmRelease\", cluster=~\"$selected_cluster\"})",
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Failing Reconcilers",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 100
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        },
+        "id": 29,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "last"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value"
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "count by(cluster) (gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"True\", kind=~\"GitRepository|HelmRepository|Bucket\", cluster=~\"$selected_cluster\"}) - sum by(cluster) (gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"Deleted\", kind=~\"GitRepository|HelmRepository|Bucket\", cluster=~\"$selected_cluster\"})",
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Kubernetes Manifests Sources",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 18,
+          "y": 0
+        },
+        "id": 30,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "last"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value"
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "sum by(cluster) (gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"False\", kind=~\"GitRepository|HelmRepository|Bucket\", cluster=~\"$selected_cluster\"})",
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Failing Sources",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 61
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 12,
+          "x": 0,
+          "y": 5
+        },
+        "id": 8,
+        "options": {
+          "displayMode": "gradient",
+          "minVizHeight": 10,
+          "minVizWidth": 0,
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "text": {}
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "exemplar": true,
+            "expr": "  sum(rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$operator_namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{namespace=~\"$operator_namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)",
+            "interval": "",
+            "legendFormat": "{{kind}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Reconciler ops avg. duration",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 61
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 12,
+          "x": 12,
+          "y": 5
+        },
+        "id": 31,
+        "options": {
+          "displayMode": "gradient",
+          "minVizHeight": 10,
+          "minVizWidth": 0,
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "text": {}
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "exemplar": true,
+            "expr": "  sum(rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$operator_namespace\",kind=~\"GitRepository|HelmRepository|Bucket\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{namespace=~\"$operator_namespace\",kind=~\"GitRepository|HelmRepository|Bucket\"}[5m])) by (kind)",
+            "interval": "",
+            "legendFormat": "{{kind}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Source ops avg. duration",
+        "type": "bargauge"
+      },
+      {
+        "collapsed": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 9
+        },
+        "id": 15,
+        "panels": [],
+        "title": "Status",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "filterable": true,
+              "inspect": false
+            },
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "text": "Ready"
+                  },
+                  "1": {
+                    "text": "Not Ready"
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "blue",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Status"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "mode": "gradient",
+                    "type": "color-background"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 10
+        },
+        "id": 33,
+        "options": {
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Status"
+            }
+          ]
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"False\", kind=~\"Kustomization|HelmRelease\", cluster=~\"$selected_cluster\"}",
+            "format": "table",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Cluster reconciliation readiness ",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true,
+                "__name__": true,
+                "app": true,
+                "container": true,
+                "endpoint": true,
+                "exported_namespace": false,
+                "instance": true,
+                "job": true,
+                "kubernetes_namespace": true,
+                "kubernetes_pod_name": true,
+                "namespace": true,
+                "pod": true,
+                "pod_template_hash": true,
+                "status": true,
+                "type": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "Value": "Status",
+                "exported_namespace": "Namespace",
+                "kind": "Kind",
+                "name": "Name",
+                "namespace": "Operator Namespace"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "filterable": true,
+              "inspect": false
+            },
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "text": "Ready"
+                  },
+                  "1": {
+                    "text": "Not Ready"
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "blue",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Status"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "mode": "gradient",
+                    "type": "color-background"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 10
+        },
+        "id": 34,
+        "options": {
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Status"
+            }
+          ]
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "gotk_reconcile_condition{namespace=~\"$operator_namespace\", type=\"Ready\", status=\"False\", kind=~\"GitRepository|HelmRepository|Bucket\", cluster=~\"$selected_cluster\"}",
+            "format": "table",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Source acquisition readiness ",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true,
+                "__name__": true,
+                "app": true,
+                "container": true,
+                "endpoint": true,
+                "exported_namespace": false,
+                "instance": true,
+                "job": true,
+                "kubernetes_namespace": true,
+                "kubernetes_pod_name": true,
+                "namespace": true,
+                "pod": true,
+                "pod_template_hash": true,
+                "status": true,
+                "type": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "Value": "Status",
+                "exported_namespace": "Namespace",
+                "kind": "Kind",
+                "name": "Name",
+                "namespace": "Operator Namespace"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "collapsed": false,
+        "datasource": "${DS_PROMETHEUS}",
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 21
+        },
+        "id": 17,
+        "panels": [],
+        "title": "Timing",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 22
+        },
+        "id": 27,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "sum by(kind, name, cluster) (rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$operator_namespace\", kind=~\"Kustomization|HelmRelease\", cluster=~\"$selected_cluster\"}[5m])) / sum by(kind, name, cluster) (rate(gotk_reconcile_duration_seconds_count{namespace=~\"$operator_namespace\", kind=~\"Kustomization|HelmRelease\", cluster=~\"$selected_cluster\"}[5m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{cluster}}/{{kind}}/{{name}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Cluster reconciliation duration",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 30
+        },
+        "id": 35,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": true,
+            "expr": "sum by(kind, name, cluster) (rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$operator_namespace\", kind=~\"GitRepository|HelmRepository|Bucket\", cluster=~\"$selected_cluster\"}[5m])) / sum by(kind, name, cluster) (rate(gotk_reconcile_duration_seconds_count{namespace=~\"$operator_namespace\", kind=~\"GitRepository|HelmRepository|Bucket\", cluster=~\"$selected_cluster\"}[5m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{cluster}}/{{kind}}/{{name}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Source acquisition duration",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "30s",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "light",
+    "tags": [
+      "flux"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "Managed_Prometheus_myworkspace",
+            "value": "Managed_Prometheus_myworkspace"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Datasource",
+          "multi": false,
+          "name": "DS_PROMETHEUS",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "allValue": "",
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "definition": "label_values(gotk_reconcile_condition, cluster)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Cluster",
+          "multi": true,
+          "name": "selected_cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(gotk_reconcile_condition, cluster)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 5,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": "",
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "definition": "label_values(gotk_reconcile_condition, namespace)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Namespace",
+          "multi": true,
+          "name": "operator_namespace",
+          "options": [],
+          "query": {
+            "query": "label_values(gotk_reconcile_condition, namespace)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 5,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-15m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "",
+    "title": "Flux Cluster Stats",
+    "uid": "flux-cluster",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/infra/core/env/observability/dashboards/flux-control-plane.json
+++ b/infra/core/env/observability/dashboards/flux-control-plane.json
@@ -1,0 +1,1540 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
+          "iconColor": "red",
+          "name": "flux events",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [
+              "flux"
+            ],
+            "type": "tags"
+          }
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 100
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
+        "id": 24,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "last"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value_and_name"
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "sum by(cluster) (go_info{kubernetes_namespace=\"$namespace\", kubernetes_pod_name=~\".*-controller-.*\", cluster=~\"$selected_cluster\"})",
+            "format": "time_series",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Controllers",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisGridShow": false,
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 23,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 50
+                },
+                {
+                  "color": "red",
+                  "value": 100
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 6,
+          "y": 0
+        },
+        "id": 23,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "max by(cluster) (workqueue_longest_running_processor_seconds{kubernetes_namespace=\"$namespace\", kubernetes_pod_name=~\".*-controller-.*\", cluster=~\"$selected_cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Max Work Queue",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 500000000
+                },
+                {
+                  "color": "red",
+                  "value": 900000000
+                }
+              ]
+            },
+            "unit": "decbits"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        },
+        "id": 25,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "text": {}
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster) (go_memstats_alloc_bytes{kubernetes_namespace=\"$namespace\", kubernetes_pod_name=~\".*-controller-.*\", cluster=~\"$selected_cluster\"})",
+            "interval": "",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Memory",
+        "type": "gauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisGridShow": false,
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 29,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "smooth",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 50
+                },
+                {
+                  "color": "red",
+                  "value": 100
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 18,
+          "y": 0
+        },
+        "id": 26,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster) (rate(rest_client_requests_total{kubernetes_namespace=\"$namespace\", kubernetes_pod_name=~\".*-controller-.*\", cluster=~\"$selected_cluster\"}[2m]))",
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "API Requests",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 5
+        },
+        "id": 21,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster) (rate(rest_client_requests_total{kubernetes_namespace=\"$namespace\", cluster=~\"$selected_cluster\"}[2m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "total {{cluster}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster) (rate(rest_client_requests_total{kubernetes_namespace=\"$namespace\", code!~\"2..\", cluster=~\"$selected_cluster\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "errors {{cluster}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Kubernetes API Requests",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 15,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Resource Usage",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 14
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "rate(process_cpu_seconds_total{kubernetes_namespace=\"$namespace\", kubernetes_pod_name=~\".*-controller-.*\", cluster=~\"$selected_cluster\"}[2m])",
+            "interval": "",
+            "legendFormat": "cluster: {{cluster}}, pod: {{kubernetes_pod_name}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "CPU Usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 14
+        },
+        "id": 13,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster, pod) (container_memory_working_set_bytes{namespace=\"$namespace\", container!=\"POD\", container!=\"\", pod=~\".*-controller-.*\", cluster=~\"$selected_cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "cluster: {{cluster}} pod: {{pod}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Memory Usage",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 25
+        },
+        "id": 17,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Reconciliation Stats",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 26
+        },
+        "hiddenSeries": false,
+        "id": 27,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.4.12",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "sum by(cluster) (workqueue_longest_running_processor_seconds{name=\"kustomization\", cluster=~\"$selected_cluster\"})",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Cluster Reconciliation Duration",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:912",
+            "format": "s",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:913",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "stepAfter",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "opm"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 34
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(controller, cluster) (increase(controller_runtime_reconcile_total{controller=\"kustomization\", result!=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "successful reconciliations {{cluster}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(controller, cluster) (increase(controller_runtime_reconcile_total{controller=\"kustomization\", result=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "failed reconciliations {{cluster}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Cluster Reconciliations ops/min",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "stepAfter",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "opm"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 34
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster) (increase(controller_runtime_reconcile_total{controller=\"gitrepository\", result!=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "successful git pulls {{cluster}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster) (increase(controller_runtime_reconcile_total{controller=\"gitrepository\", result=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "failed git pulls {{cluster}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Git Sources ops/min",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 43
+        },
+        "id": 19,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Helm Stats",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 44
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "histogram_quantile(0.5, sum by(le, cluster) (rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\", cluster=~\"$selected_cluster\"}[5m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "P50 {{cluster}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "histogram_quantile(0.9, sum by(le, cluster) (rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\", cluster=~\"$selected_cluster\"}[5m])))",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "P90 {{cluster}}",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "histogram_quantile(0.99, sum by(le, cluster) (rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\", cluster=~\"$selected_cluster\"}[5m])))",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "P99 {{cluster}}",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "Helm Release Duration",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "stepAfter",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "opm"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 52
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(controller, cluster) (increase(controller_runtime_reconcile_total{controller=\"helmrelease\", result!=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "successful reconciliations {{cluster}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(controller, cluster) (increase(controller_runtime_reconcile_total{controller=\"helmrelease\", result=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "failed reconciliations {{cluster}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Helm Releases ops/min",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "stepAfter",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "opm"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 52
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.4.12",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(controller, cluster) (increase(controller_runtime_reconcile_total{controller=\"helmchart\", result!=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "successful chart pulls {{cluster}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "builder",
+            "expr": "sum by(cluster) (increase(controller_runtime_reconcile_total{controller=\"helmchart\", result=\"error\", cluster=~\"$selected_cluster\"}[2m]))",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "failed chart pulls {{cluster}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Helm Charts ops/min",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "30s",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "light",
+    "tags": [
+      "flux"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "Managed_Prometheus_myworkspace",
+            "value": "Managed_Prometheus_myworkspace"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "DS_PROMETHEUS",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "definition": "workqueue_work_duration_seconds_count",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Cluster",
+          "multi": true,
+          "name": "selected_cluster",
+          "options": [],
+          "query": {
+            "query": "workqueue_work_duration_seconds_count",
+            "refId": "Prometheus-namespace-Variable-Query"
+          },
+          "refresh": 2,
+          "regex": "/.*cluster=\"([^\"]*).*/",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "flux-system",
+            "value": "flux-system"
+          },
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "definition": "workqueue_work_duration_seconds_count",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Namespace",
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": {
+            "query": "workqueue_work_duration_seconds_count",
+            "refId": "Prometheus-namespace-Variable-Query"
+          },
+          "refresh": 2,
+          "regex": "/.*namespace=\"([^\"]*).*/",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-15m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "",
+    "title": "Flux Control Plane",
+    "uid": "flux-control-plane",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/infra/core/env/observability/grafana.parameters.json
+++ b/infra/core/env/observability/grafana.parameters.json
@@ -20,6 +20,9 @@
         },
         "grafanaAdminsGroupObjectId": {
             "value": "#{{ grafanaAdminGroupObjectId }}"
+        },
+        "ssvAppRegServicePrincipalObjectId": {
+            "value": "#{{ ssvAppRegServicePrincipalId }}"
         }
     }
 }

--- a/infra/core/env/scripts/New-FluxDashboards.ps1
+++ b/infra/core/env/scripts/New-FluxDashboards.ps1
@@ -74,7 +74,7 @@ try {
     [string]$dashBoardExistsJson = Invoke-CommandLine -Command "az grafana dashboard list --name $GrafanaName --resource-group $ResourceGroupName --query ""[?@.folderTitle == '$fluxFolderName']"""
     [object]$dashBoardExists = $dashBoardExistsJson | ConvertFrom-Json
     foreach ($fluxDashboard in $fluxDashboards) {
-        if ($dashBoardExists.title -contains $fluxDashboard.dashBoardTitle) {
+        if ($dashBoardExists.title -notcontains $fluxDashboard.dashBoardTitle) {
             [string]$fluxDashboardPath = Join-Path -Path $DashboardsPath -ChildPath $fluxDashboard.fileName
             Write-Host "Creating $($fluxDashboard.fileName) dashboard in Grafana"
             Invoke-CommandLine -Command "az grafana dashboard import --name $GrafanaName --resource-group $ResourceGroupName --definition @$fluxDashboardPath --folder $fluxFolderName"

--- a/infra/core/env/scripts/New-FluxDashboards.ps1
+++ b/infra/core/env/scripts/New-FluxDashboards.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+Create Flux folder in Grafana and add new dashboards for flux cluster stats and flux control plane
+.DESCRIPTION
+Creates a Flux folder in Grafana and adds new dashboards for flux cluster stats and flux control plane.
+.PARAMETER ResourceGroupName
+Mandatory. Resource Group Name.
+.PARAMETER GrafanaName
+Mandatory. Grafana Dashboard name.
+.PARAMETER DashboardsPath
+Mandatory. Path to Dashboards directory containing Dashboards json files.
+.EXAMPLE
+.\New-FluxDashboards.ps1 -ResourceGroupName <ResourceGroupName> -GrafanaName <GrafanaName> -DashboardsPath <DashboardsPath>
+#> 
+
+[CmdletBinding()]
+param(
+[Parameter(Mandatory)]
+[string] $GrafanaName,
+[Parameter(Mandatory)]
+[string] $ResourceGroupName,
+[Parameter(Mandatory)]
+[string] $DashboardsPath,
+[Parameter()]
+[string]$WorkingDirectory = $PWD
+)
+
+Set-StrictMode -Version 3.0
+
+[string]$functionName = $MyInvocation.MyCommand
+[datetime]$startTime = [datetime]::UtcNow
+
+[int]$exitCode = -1
+[bool]$setHostExitCode = (Test-Path -Path ENV:TF_BUILD) -and ($ENV:TF_BUILD -eq "true")
+[bool]$enableDebug = (Test-Path -Path ENV:SYSTEM_DEBUG) -and ($ENV:SYSTEM_DEBUG -eq "true")
+
+Set-Variable -Name ErrorActionPreference -Value Continue -scope global
+Set-Variable -Name InformationPreference -Value Continue -Scope global
+
+if ($enableDebug) {
+    Set-Variable -Name VerbosePreference -Value Continue -Scope global
+    Set-Variable -Name DebugPreference -Value Continue -Scope global
+}
+
+Write-Host "${functionName} started at $($startTime.ToString('u'))"
+Write-Debug "${functionName}:ResourceGroupName=$ResourceGroupName"
+Write-Debug "${functionName}:GrafanaName=$GrafanaName"
+Write-Debug "${functionName}:DashboardsPath=$DashboardsPath"
+
+try {
+
+    [System.IO.DirectoryInfo]$moduleDir = Join-Path -Path $WorkingDirectory -ChildPath "scripts/modules/ps-helpers"
+    Write-Debug "${functionName}:moduleDir.FullName=$($moduleDir.FullName)"
+    Import-Module $moduleDir.FullName -Force
+    
+    Write-Host "Add azure managed grafana extension"
+    Invoke-CommandLine -Command "az extension add --upgrade -n amg"
+    Write-Host "Added extension"
+
+    [string]$fluxFolderName = 'Flux'
+    [string]$folderExistsJson = Invoke-CommandLine -Command "az grafana folder list --name $GrafanaName --query ""[?@.title == '$fluxFolderName']"""
+    [object]$folderExists = $folderExistsJson | ConvertFrom-Json
+    if ($NULL -eq $folderExists) {
+        Write-Host "Creating new folder $fluxFolderName in Grafana"
+        Invoke-CommandLine -Command "az grafana folder create --name $GrafanaName --title $fluxFolderName"
+        Write-Host "Created new folder"
+    }
+
+    [array]$fluxDashboards = @(
+        @{fileName="flux-cluster-stats.json";dashBoardTitle="Flux Cluster Stats"}
+        @{fileName="flux-control-plane.json";dashBoardTitle="Flux Control Plane"}
+        @{fileName="flux-application-deployments.json";dashBoardTitle="GitOps Flux - Application Deployments Dashboard"}
+    )
+    foreach ($fluxDashboard in $fluxDashboards) {
+        [string]$dashBoardExistsJson = Invoke-CommandLine -Command "az grafana dashboard list --name $GrafanaName --resource-group $ResourceGroupName --query ""[?@.title == '$($fluxDashboard.dashBoardTitle)']"""
+        [object]$dashBoardExists = $dashBoardExistsJson | ConvertFrom-Json
+        if ($NULL -eq $dashBoardExists) {
+            [string]$fluxDashboardPath = Join-Path -Path $DashboardsPath -ChildPath $fluxDashboard.fileName
+            Write-Host "Creating $($fluxDashboard.fileName) dashboard in Grafana"
+            Invoke-CommandLine -Command "az grafana dashboard import --name $GrafanaName --resource-group $ResourceGroupName --definition @$fluxDashboardPath --folder $fluxFolderName"
+            Write-Host "Created dashboard in Grafana"
+        }
+    }
+
+    $exitCode = 0
+}
+catch {
+    $exitCode = -2
+    Write-Error $_.Exception.ToString()
+    throw $_.Exception
+}
+finally {
+    [DateTime]$endTime = [DateTime]::UtcNow
+    [Timespan]$duration = $endTime.Subtract($startTime)
+
+    Write-Host "${functionName} finished at $($endTime.ToString('u')) (duration $($duration -f 'g')) with exit code $exitCode"
+    if ($setHostExitCode) {
+        Write-Debug "${functionName}:Setting host exit code"
+        $host.SetShouldExit($exitCode)
+    }
+    exit $exitCode
+}

--- a/infra/core/env/scripts/New-FluxDashboards.ps1
+++ b/infra/core/env/scripts/New-FluxDashboards.ps1
@@ -71,10 +71,10 @@ try {
         @{fileName="flux-control-plane.json";dashBoardTitle="Flux Control Plane"}
         @{fileName="flux-application-deployments.json";dashBoardTitle="GitOps Flux - Application Deployments Dashboard"}
     )
+    [string]$dashBoardExistsJson = Invoke-CommandLine -Command "az grafana dashboard list --name $GrafanaName --resource-group $ResourceGroupName --query ""[?@.folderTitle == '$fluxFolderName']"""
+    [object]$dashBoardExists = $dashBoardExistsJson | ConvertFrom-Json
     foreach ($fluxDashboard in $fluxDashboards) {
-        [string]$dashBoardExistsJson = Invoke-CommandLine -Command "az grafana dashboard list --name $GrafanaName --resource-group $ResourceGroupName --query ""[?@.title == '$($fluxDashboard.dashBoardTitle)']"""
-        [object]$dashBoardExists = $dashBoardExistsJson | ConvertFrom-Json
-        if ($NULL -eq $dashBoardExists) {
+        if ($dashBoardExists.title -contains $fluxDashboard.dashBoardTitle) {
             [string]$fluxDashboardPath = Join-Path -Path $DashboardsPath -ChildPath $fluxDashboard.fileName
             Write-Host "Creating $($fluxDashboard.fileName) dashboard in Grafana"
             Invoke-CommandLine -Command "az grafana dashboard import --name $GrafanaName --resource-group $ResourceGroupName --definition @$fluxDashboardPath --folder $fluxFolderName"

--- a/infra/core/env/scripts/New-FluxDashboards.ps1
+++ b/infra/core/env/scripts/New-FluxDashboards.ps1
@@ -60,7 +60,7 @@ try {
     [string]$fluxFolderName = 'Flux'
     [string]$folderExistsJson = Invoke-CommandLine -Command "az grafana folder list --name $GrafanaName --query ""[?@.title == '$fluxFolderName']"""
     [object]$folderExists = $folderExistsJson | ConvertFrom-Json
-    if ($NULL -eq $folderExists) {
+    if ([string]::IsNullOrEmpty($folderExists)) {
         Write-Host "Creating new folder $fluxFolderName in Grafana"
         Invoke-CommandLine -Command "az grafana folder create --name $GrafanaName --title $fluxFolderName"
         Write-Host "Created new folder"
@@ -73,8 +73,9 @@ try {
     )
     [string]$dashBoardExistsJson = Invoke-CommandLine -Command "az grafana dashboard list --name $GrafanaName --resource-group $ResourceGroupName --query ""[?@.folderTitle == '$fluxFolderName']"""
     [object]$dashBoardExists = $dashBoardExistsJson | ConvertFrom-Json
+
     foreach ($fluxDashboard in $fluxDashboards) {
-        if ($dashBoardExists.title -notcontains $fluxDashboard.dashBoardTitle) {
+        if ([string]::IsNullOrEmpty($dashBoardExists) -or $dashBoardExists.title -notcontains $fluxDashboard.dashBoardTitle) {
             [string]$fluxDashboardPath = Join-Path -Path $DashboardsPath -ChildPath $fluxDashboard.fileName
             Write-Host "Creating $($fluxDashboard.fileName) dashboard in Grafana"
             Invoke-CommandLine -Command "az grafana dashboard import --name $GrafanaName --resource-group $ResourceGroupName --definition @$fluxDashboardPath --folder $fluxFolderName"


### PR DESCRIPTION
# **What this PR does / why we need it**:

- Automated adding Flux Dashboards which were previously added manually. The 3 Dashboards are:

1. flux-cluster-stats
2. flux-control-plane
3. GitOps Flux - Application Deployments Dashboard

Reference: https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/monitor-gitops-flux-2

- Granted 'Grafana Admin' permission to the ADO SSV3 (ADO-DefraGovUK-AAD-ADP-SSV3) service principal on the Azure Managed Grafana instance.  This is required to allow the pipeline to create the Dashboards in Grafana

- The PowerShell script will check for existence of the 'Flux' folder and the new dashboards.  If they don't exist they will get created.

- Resolved permissions error which occurred when viewing AppInsights dashboard in Grafana.  This was done by granting 'Reader' permission on the environment subscriptions (e.g. AZD-ADP-SND1) to the Grafana system assigned identity.

[AB#241036](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/241036)

# **Special notes for your reviewer**
Flux dashboards JSON taken from this MS document.
https://learn.microsoft.com/en-us/azure/azure-arc/kubernetes/monitor-gitops-flux-2

# Testing
*Any relevant testing information and pipeline runs.*
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=420073&view=logs&s=22b90175-456f-5b2f-3825-ad433f1ac1d9

DashBoards can be viewed in Grafana under the Flux folder:
https://ssvadpinfmg3401-apa8eed9b2hsc2an.suk.grafana.azure.com/dashboards

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/3oJob1xJrLWH7oL9F6/giphy.gif)
