### PR TITLE
277122: Replace aks and flux bicep module prerelease versions with latest versions

### DIFF
--- a/infra/core/env/managed-cluster/aks-cluster.bicep
+++ b/infra/core/env/managed-cluster/aks-cluster.bicep
@@ -240,7 +240,7 @@ module kmsKeyVaultRbac '.bicep/keyvault-rbac.bicep' = [for kmsKeyVaultRbac in km
 }
 ]
 
-module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.15-prerelease' = {
+module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.16' = {
   name: 'aks-cluster-${deploymentDate}'
   dependsOn: [
     privateDnsZoneContributor
@@ -348,7 +348,7 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.1
   }
 }
 
-module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.extension:0.4.4-prerelease' = {
+module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.extension:0.4.5' = {
   name: 'flux-extension-${deploymentDate}'
   params: {
     clusterName: cluster.name

--- a/infra/core/env/managed-cluster/aks-cluster.bicep
+++ b/infra/core/env/managed-cluster/aks-cluster.bicep
@@ -348,7 +348,7 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.1
   }
 }
 
-module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.extension:0.4.5' = {
+module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.extension:0.4.4-prerelease' = {
   name: 'flux-extension-${deploymentDate}'
   params: {
     clusterName: cluster.name

--- a/infra/core/env/managed-cluster/aks-cluster.bicep
+++ b/infra/core/env/managed-cluster/aks-cluster.bicep
@@ -348,7 +348,7 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.1
   }
 }
 
-module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.extension:0.4.4-prerelease' = {
+module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.extension:0.4.5' = {
   name: 'flux-extension-${deploymentDate}'
   params: {
     clusterName: cluster.name


### PR DESCRIPTION

# **What this PR does / why we need it**:
The PRs we raised with Microsoft for adding AzureMonitorProfile ( Prometheus logs ) to the AKS Bicep module and updating the Flux configuration bicep to allow for postbuild variables have been completed and merged into main.

This change will now replace the prerelease versions with the latest version of Bicep modules.

https://github.com/Azure/ResourceModules/pull/4142
https://github.com/Azure/ResourceModules/pull/4331

[AB#277122](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/277122)

# Testing
*Any relevant testing information and pipeline runs.*
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=421276&view=logs&s=aee76c8a-1d8b-5149-1924-86de92a850c9

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/PnpkimJ5mrZRe/giphy.gif)
