### PR TITLE
287810: Fix image policy for flux service pre-deploy

### DIFF
--- a/flux-templates/templates/programme/team/service/pre-deploy/environment/image-policy.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/environment/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: __SERVICE_NAME__-dbmigration-__ENVIRONMENT__-01
+  name: __SERVICE_NAME__-dbmigration-__ENVIRONMENT__-0__ENV_INSTANCE__
   namespace: flux-config
 spec:
   imageRepositoryRef:


### PR DESCRIPTION
All SND pre-deploy image policies are pointing to SND1.  This PR will fix the automation that generates the manifests.

[AB#287810](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/287810)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/xT9IgNPVbGsa0Wd8li/giphy.gif)
