### PR TITLE
267988: Database Permission Management and Migration for PostgresDB Flux Manifests Automation

### DIFF
--- a/flux-templates/README.md
+++ b/flux-templates/README.md
@@ -18,11 +18,13 @@ Please see example manifests below:
                 },
                 {
                     "name": "claim-service", // MANDATORY
-                    "backend": true // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "backend": true, // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "dbname": "databasename" // REQUIRED - IF backend is set to true
                 },
                 {
                     "name": "payment-service", // MANDATORY
-                    "backend": true // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "backend": true, // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "dbname": "databasename" // REQUIRED - IF backend is set to true
                 },
                 {
                     "name": "payment-web-service", // MANDATORY

--- a/flux-templates/manifest/full-onboarding-manifest.json
+++ b/flux-templates/manifest/full-onboarding-manifest.json
@@ -10,11 +10,13 @@
                 },
                 {
                     "name": "claim-service", // MANDATORY
-                    "backend": true // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "backend": true, // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "dbname": "dbname" // REQUIRED - IF backend is set to true
                 },
                 {
                     "name": "payment-service", // MANDATORY
-                    "backend": true // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "backend": true, // OPTIONAL - ADD IF DBMIGRATION IS REQUIRED
+                    "dbname": "dbname" // REQUIRED - IF backend is set to true
                 },
                 {
                     "name": "payment-web-service", // MANDATORY

--- a/flux-templates/templates/programme/team/base/patch/kustomize.yaml
+++ b/flux-templates/templates/programme/team/base/patch/kustomize.yaml
@@ -20,6 +20,7 @@ spec:
       APPCONFIG_MI_CLIENTID: ${APPCONFIG_MI_CLIENTID}
       APPCONFIG_NAME: ${APPCONFIG_NAME}
       SERVICE_CODE: "__SERVICE_CODE__"
+      PLATFORM_DB_ADMIN: "adp-platform-db-aad-admin"
     substituteFrom:
       - kind: ConfigMap
         name: __TEAM_NAME__-mi-credential

--- a/flux-templates/templates/programme/team/service/deploy/environment/patch.yaml
+++ b/flux-templates/templates/programme/team/service/deploy/environment/patch.yaml
@@ -18,10 +18,10 @@ spec:
       priorityClassName: default
     container:
       imagePullPolicy: Always
-      requestMemory: 5Mi
-      requestCpu: 5m
-      limitMemory: 60Mi
-      limitCpu: 40m
+      requestMemory: 50Mi
+      requestCpu: 50m
+      limitMemory: 200Mi
+      limitCpu: 400m
     containerConfigMap:
       configServiceName: ${APPCONFIG_NAME}
       configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}

--- a/flux-templates/templates/programme/team/service/pre-deploy-kustomize.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy-kustomize.yaml
@@ -23,6 +23,10 @@ spec:
       SERVICE_NAME: "__SERVICE_NAME__"
       TEAM_NAMESPACE: ${TEAM_NAMESPACE}
       TEAM_NAME: ${TEAM_NAME}
+      PLATFORM_DB_ADMIN: ${PLATFORM_DB_ADMIN}
+      POSTGRES_DB: "__POSTGRES_DB__"
+      POSTGRES_PORT: "\"5432\""
+      POSTGRES_SCHEMA_NAME: "public"
     substituteFrom:
       - kind: ConfigMap
         name: adp-platform-vars

--- a/flux-templates/templates/programme/team/service/pre-deploy/base/kustomization.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/base/kustomization.yaml
@@ -3,4 +3,6 @@ kind: Kustomization
 resources:
   - ../../../../../base/service-account.yaml
   - image-repository-dbmigration.yaml
+  - pre-migration-script.job.yaml
   - migration.job.yaml
+  - post-migration-script.job.yaml

--- a/flux-templates/templates/programme/team/service/pre-deploy/base/post-migration-script.job.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/base/post-migration-script.job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: __SERVICE_NAME__-dbmigration
+  name: __SERVICE_NAME__-post-dbmigration
   namespace: __TEAM_NAME__
   labels:
     azure.workload.identity/use: "true"
@@ -14,5 +14,5 @@ spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never
       containers:
-      - name: __SERVICE_NAME__-dbmigration
+      - name: __SERVICE_NAME__-post-dbmigration
         imagePullPolicy: Always

--- a/flux-templates/templates/programme/team/service/pre-deploy/base/pre-migration-script.job.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/base/pre-migration-script.job.yaml
@@ -1,8 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: __SERVICE_NAME__-dbmigration
-  namespace: __TEAM_NAME__
+  name: __SERVICE_NAME__-pre-dbmigration
+  namespace: flux-config
   labels:
     azure.workload.identity/use: "true"
 spec:
@@ -11,8 +11,8 @@ spec:
       labels:
         azure.workload.identity/use: "true"
     spec:
-      serviceAccountName: ${TEAM_NAMESPACE}
+      serviceAccountName: ${PLATFORM_DB_ADMIN}
       restartPolicy: Never
       containers:
-      - name: __SERVICE_NAME__-dbmigration
+      - name: __SERVICE_NAME__-pre-dbmigration
         imagePullPolicy: Always

--- a/flux-templates/templates/programme/team/service/pre-deploy/environment/image-policy.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/environment/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: __SERVICE_NAME__-dbmigration-__ENVIRONMENT__-01
+  name: __SERVICE_NAME__-dbmigration-__ENVIRONMENT__-0__ENV_INSTANCE__
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/flux-templates/templates/programme/team/service/pre-deploy/environment/kustomization.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/environment/kustomization.yaml
@@ -4,4 +4,15 @@ resources:
   - ../../base
   - image-policy.yaml
 patches:
-  - path: patch.yaml
+  - path: pre-migration-script-patch.yaml
+    target:
+      kind: Job
+      name: __SERVICE_NAME__-pre-dbmigration
+  - path: migration-patch.yaml
+    target:
+      kind: Job
+      name: __SERVICE_NAME__-dbmigration
+  - path: post-migration-script-patch.yaml
+    target:
+      kind: Job
+      name: __SERVICE_NAME__-post-dbmigration

--- a/flux-templates/templates/programme/team/service/pre-deploy/environment/migration-patch.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/environment/migration-patch.yaml
@@ -8,15 +8,15 @@ spec:
     spec:
       containers:
       - name: __SERVICE_NAME__-dbmigration
-        image: __ENVIRONMENT__adpinfcr__ENV_INSTANCE__401.azurecr.io/image/__SERVICE_NAME__-dbmigration:0.1.0 # {"$imagepolicy": "flux-config:__SERVICE_NAME__-dbmigration-__ENVIRONMENT__-0__ENV_INSTANCE__"}
+        image: __ENVIRONMENT__adpinfcr__ENV_INSTANCE__401.azurecr.io/image/__SERVICE_NAME__-dbmigration:5.1.27 # {"$imagepolicy": "flux-config:__SERVICE_NAME__-dbmigration-__ENVIRONMENT__-0__ENV_INSTANCE__"}
         env:
         - name: POSTGRES_HOST
           value: "${SHARED_POSTGRES_SERVER_01}.postgres.database.azure.com"
         - name: SCHEMA_NAME
-          value: "public"
+          value: ${POSTGRES_SCHEMA_NAME}
         - name: POSTGRES_DB
-          value: "${POSTGRES_DB}"
+          value: ${POSTGRES_DB}
         - name: POSTGRES_PORT
-          value: "5432"
+          value: "${POSTGRES_PORT}"
         - name: SCHEMA_USERNAME
-          value: ${TEAM_MI_PREFIX}-${SERVICE_NAME}
+          value: ${TEAM_MI_PREFIX}-${TEAM_NAMESPACE}

--- a/flux-templates/templates/programme/team/service/pre-deploy/environment/post-migration-script-patch.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/environment/post-migration-script-patch.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: __SERVICE_NAME__-post-dbmigration
+  namespace: __TEAM_NAME__
+spec:
+  template:
+    spec:
+      containers:
+      - name: __SERVICE_NAME__-post-dbmigration
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        env:
+        - name: GIT_REPO_URL
+          value: "https://github.com/DEFRA/adp-flux-services.git"
+        - name: GIT_BRANCH
+          value: "main"
+        - name: SCRIPT_FILE_NAME
+          value: "common/scripts/access-control/flexible-server/Grant-FlexibleServerDBAccess.ps1"
+        - name: POSTGRES_HOST
+          value: "${SHARED_POSTGRES_SERVER_01}.postgres.database.azure.com"
+        - name: POSTGRES_DATABASE
+          value: ${POSTGRES_DB}
+        - name: SERVICE_MI_NAME
+          value: ${TEAM_MI_PREFIX}-${SERVICE_NAME}
+        - name: TEAM_MI_NAME
+          value: ${TEAM_MI_PREFIX}-${TEAM_NAMESPACE}
+        - name: TEAM_MI_SUBSCRIPTION_ID
+          value: ${SUBSCRIPTION_ID}
+        - name: SUBSCRIPTION_NAME
+          value: ${SUBSCRIPTION_NAME}
+        - name: DB_MIGRATION_VERSION
+          value: "0.1.0" # {"$imagepolicy": "flux-config:__SERVICE_NAME__-dbmigration-__ENVIRONMENT__-0__ENV_INSTANCE__:tag"}

--- a/flux-templates/templates/programme/team/service/pre-deploy/environment/pre-migration-script-patch.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/environment/pre-migration-script-patch.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: __SERVICE_NAME__-pre-dbmigration
+  namespace: flux-config
+spec:
+  template:
+    spec:
+      containers:
+      - name: __SERVICE_NAME__-pre-dbmigration
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        env:
+        - name: GIT_REPO_URL
+          value: "https://github.com/DEFRA/adp-flux-services.git"
+        - name: GIT_BRANCH
+          value: "main"
+        - name: SCRIPT_FILE_NAME
+          value: "common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess.ps1"
+        - name: POSTGRES_HOST
+          value: "${SHARED_POSTGRES_SERVER_01}.postgres.database.azure.com"
+        - name: POSTGRES_DATABASE
+          value: ${POSTGRES_DB}
+        - name: SERVICE_MI_NAME
+          value: ${TEAM_MI_PREFIX}-${SERVICE_NAME}
+        - name: TEAM_MI_NAME
+          value: ${TEAM_MI_PREFIX}-${TEAM_NAMESPACE}
+        - name: PLATFORM_MI_NAME
+          value: ${TEAM_MI_PREFIX}-${PLATFORM_DB_ADMIN}
+        - name: PLATFORM_MI_SUBSCRIPTION_ID
+          value: ${SUBSCRIPTION_ID}
+        - name: SUBSCRIPTION_NAME
+          value: ${SUBSCRIPTION_NAME}


### PR DESCRIPTION
This PR contains changes to the Flux Manifest Onboarding Automation to now include files required for Postgres DB Migration.

[AB#267988](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/267988)
[AB#287824](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/287824)

# Testing
All Flux manifests have successfully reconciled.
![image](https://github.com/DEFRA/adp-flux-services/assets/39670555/00060529-c490-4ab2-8714-f033ee6818a3)


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/UwlX8g3HF8Uec/giphy.gif)
