### PR TITLE
292768: Add image policy for powershell executor to environment specific folder via automation

### DIFF
--- a/flux-templates/scripts/New-FluxServices.ps1
+++ b/flux-templates/scripts/New-FluxServices.ps1
@@ -163,6 +163,7 @@ try {
 
     [string]$programmePath = "$FluxServicesPath/$programmeName"
     [string]$environmentsPath = "$FluxServicesPath/environments"
+    [string]$templateEnvironmentsPath = "$TemplatesPath/environments"
     [string]$templateProgrammePath = "$TemplatesPath/programme"
     [string]$templateTeamPath = "$templateProgrammePath/team"
     [string]$templateTeamBasePath = "$templateTeamPath/base"
@@ -272,7 +273,9 @@ try {
 
         # CREATE ENVIRONMENT DIRECTORIES AND FILES
         foreach ($environment in $team.environments) {
+            $lookupTable['__ENVIRONMENT__'] = $($environment.name)
             foreach ($instance in $environment.instances) {
+                $lookupTable['__ENV_INSTANCE__'] = $instance
                 New-Directory -DirectoryPath "$programmePath/$($team.name)/$($environment.name)/0$instance"
                 Copy-Item -Path "$templateTeamEnvironmentPath/*" -Destination $programmePath/$($team.name)/$($environment.name)/0$instance -Recurse
         
@@ -286,6 +289,9 @@ try {
                         Add-Content -Path $programmePath/$($team.name)/$($environment.name)/0$instance/kustomization.yaml -Value "  - ../../$($service.name)"
                     }
                 }
+
+                Copy-Item -Path "$templateEnvironmentsPath/environment/kustomization.yaml" -Destination "$environmentsPath/$($environment.name)/0$instance/kustomization.yaml"
+                ReplaceTokens -TemplateFile "$templateEnvironmentsPath/environment/ps-exec-image-policy.yaml" -DestinationFile "$environmentsPath/$($environment.name)/0$instance/ps-exec-image-policy.yaml"
             }
 
             $pathExistsInKustomization = Select-String -Path "$environmentsPath/$($environment.name)/base/kustomization.yaml" -Pattern "  - ../../../$($programmeName)/$($team.name)/base/patch"

--- a/flux-templates/templates/environments/environment/kustomization.yaml
+++ b/flux-templates/templates/environments/environment/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: cluster-base
+resources:
+  - kustomize.yaml
+  - ../base
+  - ps-exec-image-policy.yaml
+  

--- a/flux-templates/templates/environments/environment/ps-exec-image-policy.yaml
+++ b/flux-templates/templates/environments/environment/ps-exec-image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: powershell-executor-__ENVIRONMENT__-0__ENV_INSTANCE__
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: powershell-executor
+  policy:
+    numerical:
+      order: asc

--- a/flux-templates/templates/programme/team/service/pre-deploy/post-migration/environment/post-migration-script-patch.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/post-migration/environment/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: __SERVICE_NAME__-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-__ENVIRONMENT__-0__ENV_INSTANCE__"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/flux-templates/templates/programme/team/service/pre-deploy/pre-migration/environment/pre-migration-script-patch.yaml
+++ b/flux-templates/templates/programme/team/service/pre-deploy/pre-migration/environment/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: __SERVICE_NAME__-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-__ENVIRONMENT__-0__ENV_INSTANCE__"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"


### PR DESCRIPTION
We noticed the Powershell executor image policy wasn't setup correctly when deployed to DEV environment.  After investigation it was setup at the wrong level which was causing multiple commits by the image automation because environments were conflicting with each other.  The image policy has now been moved into the environment specific folders to resolve the issue.

# **What this PR does / why we need it**:
*A brief description of changes being made*
*Link to the relevant work items: e.g: Relates to ADO Work Item [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) and builds on #3376 (link to ADO Build ID URL)*

[AB#292768](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/292768)
[AB#259850](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/259850)

Testing:
Checked all manifest have reconciled successfully in SND1

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
