### PR TITLE
286235: Remove cpu and memory settings from flux patches and add KeyVault to appconfig

### DIFF
--- a/flux-templates/templates/programme/team/service/deploy/environment/patch-frontend.yaml
+++ b/flux-templates/templates/programme/team/service/deploy/environment/patch-frontend.yaml
@@ -18,10 +18,6 @@ spec:
       component: web
     container:
       imagePullPolicy: Always
-      requestMemory: 50Mi
-      requestCpu: 50m
-      limitMemory: 200Mi
-      limitCpu: 400m
     ingress:
       class: nginx
       endpoint: __SERVICE_NAME__

--- a/flux-templates/templates/programme/team/service/deploy/environment/patch.yaml
+++ b/flux-templates/templates/programme/team/service/deploy/environment/patch.yaml
@@ -18,10 +18,6 @@ spec:
       priorityClassName: default
     container:
       imagePullPolicy: Always
-      requestMemory: 50Mi
-      requestCpu: 50m
-      limitMemory: 200Mi
-      limitCpu: 400m
     containerConfigMap:
       configServiceName: ${APPCONFIG_NAME}
       configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}

--- a/flux-templates/templates/programme/team/service/infra/environment/patch-backend.yaml
+++ b/flux-templates/templates/programme/team/service/infra/environment/patch-backend.yaml
@@ -21,7 +21,7 @@ spec:
     teamMIPrefix: ${TEAM_MI_PREFIX}
     serviceName: ${SERVICE_NAME}
     keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
-    keyVaultName: __ENVIRONMENT__adpinfvt__ENV_INSTANCE__401
+    keyVaultName: ${APPLICATION_KEYVAULT}
     userAssignedIdentity:
       federatedCreds:
         - namespace: ${TEAM_NAMESPACE}

--- a/flux-templates/templates/programme/team/service/infra/environment/patch.yaml
+++ b/flux-templates/templates/programme/team/service/infra/environment/patch.yaml
@@ -19,7 +19,7 @@ spec:
     teamMIPrefix: ${TEAM_MI_PREFIX}
     serviceName: ${SERVICE_NAME}
     keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
-    keyVaultName: __ENVIRONMENT__adpinfvt__ENV_INSTANCE__401
+    keyVaultName: ${APPLICATION_KEYVAULT}
     userAssignedIdentity:
       federatedCreds:
         - namespace: ${TEAM_NAMESPACE}

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -118,5 +118,11 @@
     "value": "{\"uri\":\"https://#{{ ssvPlatformKeyVaultName }}.vault.azure.net/secrets/#{{ environment }}#{{ nc_instance_regionid }}0#{{ environmentId }}-ADP-Flux-Services-SSH-Identity-Known-Hosts\"}",
     "label": "adp-platform",
     "contentType": "text/plain"
+  },
+  {
+    "key": "APPLICATION_KEYVAULT",
+    "value": "#{{ infraResourceNamePrefix }}#{{ nc_resource_keyvault }}#{{ nc_instance_regionid }}01",
+    "label": "adp-platform",
+    "contentType": "text/plain"
   }
 ]


### PR DESCRIPTION
There is a requirement to abstract Memory and CPU Requests/Limits from flux-services into ADP-helm-library.  This change removes the CPU and Memory settings from the patches which are generated by the Onboarding Automation.  This means the values provided by the project team will take affect.  The project team will now be able to select Tiers for CPU and Memory for easier onboarding. 

The change also includes adding the Application KeyVault name to app configuration, so it can be references from the platform config map instead of being hard-coded in the Flux manifests.

[AB#286235](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/286235)
[AB#294359](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/294359)

# Testing
The changes have been tested against SND1 and all flux manifests have reconciled successfully.

![image](https://github.com/DEFRA/adp-infrastructure-core/assets/39670555/7a71117e-2d00-4f34-954c-53311da68823)


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/YKFR0dauxYEzJA8J6U/giphy-downsized-large.gif)
