### PR TITLE
295007: Comment out PRD stages until we have PRD vars ready

### DIFF
--- a/.azuredevops/deploy-platform-bootstrap-env.yaml
+++ b/.azuredevops/deploy-platform-bootstrap-env.yaml
@@ -109,14 +109,14 @@ extends:
           - 'refs/heads/main'
         azureRegions:
           primary: 'UKSouth'
-      - name: 'prd1'
-        dependsOn: 'pre1'
-        outputTemplateChange: Skip
-        serviceConnection: AZR-ADP-SSV5
-        deploymentBranches:
-          - 'refs/heads/main'
-        azureRegions:
-          primary: 'UKSouth'    
+      # - name: 'prd1'
+      #   dependsOn: 'pre1'
+      #   outputTemplateChange: Skip
+      #   serviceConnection: AZR-ADP-SSV5
+      #   deploymentBranches:
+      #     - 'refs/heads/main'
+      #   azureRegions:
+      #     primary: 'UKSouth'    
     filePathsForTransform: |
       **/bootstrap/env/config/app-registrations/tier2-app-registration.json
       **/bootstrap/env/config/service-connections/tier2-service-connection.json

--- a/.azuredevops/deploy-platform-build-agent.yaml
+++ b/.azuredevops/deploy-platform-build-agent.yaml
@@ -98,13 +98,13 @@ extends:
           - 'refs/heads/main'
         azureRegions:
           primary: 'UKSouth'
-      - name: 'prd1'
-        serviceConnection: AZR-ADP-PRD1
-        dependsOn: 'pre1'
-        deploymentBranches:
-          - 'refs/heads/main'
-        azureRegions:
-          primary: 'UKSouth'
+      # - name: 'prd1'
+      #   serviceConnection: AZR-ADP-PRD1
+      #   dependsOn: 'pre1'
+      #   deploymentBranches:
+      #     - 'refs/heads/main'
+      #   azureRegions:
+      #     primary: 'UKSouth'
     groupedDeployments:
       - name: build_agent
         deployments:


### PR DESCRIPTION
We can't add the PRD stage until we have defined the PRD vars in pipeline common.  As we don't know what some of those values will be yet, we need to remove the PRD stage, so pipelines aren't prevented from running.

[AB#259850](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/259850)
[AB#295007](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/295007)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
