### PR TITLE
295007: Comment out PRE stages until tomorrow as their are dependencies that need to be implemented first

### DIFF
--- a/.azuredevops/deploy-platform-build-agent.yaml
+++ b/.azuredevops/deploy-platform-build-agent.yaml
@@ -91,13 +91,13 @@ extends:
           - 'refs/heads/main'
         azureRegions:
           primary: 'UKSouth'
-      - name: 'pre1'
-        serviceConnection: AZR-ADP-PRE1
-        dependsOn: 'tst1'
-        deploymentBranches:
-          - 'refs/heads/main'
-        azureRegions:
-          primary: 'UKSouth'
+      # - name: 'pre1'
+      #   serviceConnection: AZR-ADP-PRE1
+      #   dependsOn: 'tst1'
+      #   deploymentBranches:
+      #     - 'refs/heads/main'
+      #   azureRegions:
+      #     primary: 'UKSouth'
       # - name: 'prd1'
       #   serviceConnection: AZR-ADP-PRD1
       #   dependsOn: 'pre1'


### PR DESCRIPTION
We can't add the PRE stage until we have deployed dependencies, such as the PRE build agents.  Will uncomment tomorrow once we have dealt with the dependencies.

[AB#259850](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/259850)
[AB#295007](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/295007)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
