### PR TITLE
248312: Implement Azure Kubernetes network policies with Calico

### DIFF
--- a/infra/core/env/managed-cluster/.bicep/keyvault-secret-rbac.bicep
+++ b/infra/core/env/managed-cluster/.bicep/keyvault-secret-rbac.bicep
@@ -1,0 +1,48 @@
+@description('Required. The name of the key vault.')
+param keyVaultName string
+
+@description('Required. The name of the secret.')
+param secretName string
+
+@description('Required. The role assignment object.')
+param roleAssignment object
+
+var builtInRoleNames = {
+  Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  'Key Vault Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+  'Key Vault Certificates Officer': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')
+  'Key Vault Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')
+  'Key Vault Crypto Officer': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')
+  'Key Vault Crypto Service Encryption User': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')
+  'Key Vault Crypto User': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424')
+  'Key Vault Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')
+  'Key Vault Secrets Officer': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')
+  'Key Vault Secrets User': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
+  Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  Reader: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Role Based Access Control Administrator (Preview)': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')
+  'User Access Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: keyVaultName
+}
+
+resource secret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' existing = {
+  name: secretName
+  parent: keyVault
+}
+
+resource secret_roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(secret.id, roleAssignment.principalId, roleAssignment.roleDefinitionIdOrName)
+  properties: {
+    roleDefinitionId: contains(builtInRoleNames, roleAssignment.roleDefinitionIdOrName) ? builtInRoleNames[roleAssignment.roleDefinitionIdOrName] : roleAssignment.roleDefinitionIdOrName
+    principalId: roleAssignment.principalId
+    description: roleAssignment.?description
+    principalType: roleAssignment.?principalType
+    condition: roleAssignment.?condition
+    conditionVersion: !empty(roleAssignment.?condition) ? (roleAssignment.?conditionVersion ?? '2.0') : null // Must only be set if condtion is set
+    delegatedManagedIdentityResourceId: roleAssignment.?delegatedManagedIdentityResourceId
+  }
+  scope: secret
+}

--- a/infra/core/env/managed-cluster/aks-cluster.bicep
+++ b/infra/core/env/managed-cluster/aks-cluster.bicep
@@ -408,6 +408,7 @@ module fluxExtensionResource 'br/SharedDefraRegistry:kubernetes-configuration.ex
                 SUBSCRIPTION_ID: subscription().subscriptionId
                 TENANT_ID: tenant().tenantId
                 LOAD_BALANCER_SUBNET: vnet.subnet01Name
+                LOAD_BALANCER_SUBNET_ADDRESS_PREFIX: vnet.subnet1AddressPrefix
                 SHARED_CONTAINER_REGISTRY: containerRegistries[0].name
               }
             }

--- a/infra/core/env/managed-cluster/aks-cluster.bicep
+++ b/infra/core/env/managed-cluster/aks-cluster.bicep
@@ -116,9 +116,6 @@ var systemNodePool = {
   nodeTaints: [
     'CriticalAddonsOnly=true:NoSchedule'
   ]
-  nodeLabels: {
-    Ingress: 'true'
-  }
 }
 
 module managedIdentity 'br/SharedDefraRegistry:managed-identity.user-assigned-identity:0.4.3' = {

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -89,7 +89,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'feature/debug'
+      branch: 'feature/debug-calico-backup'
     }
     kustomizations: {
       timeoutInSeconds: 600

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -4,6 +4,7 @@ param vnet = {
   name: '#{{ virtualNetworkName }}'
   resourceGroup: '#{{ virtualNetworkResourceGroup }}'
   subnet01Name: '#{{ networkResourceNamePrefix }}#{{ nc_resource_subnet }}#{{ nc_instance_regionid }}01'
+  subnet1AddressPrefix: '#{{ subnet1AddressPrefix }}'
   subnet02Name: '#{{ networkResourceNamePrefix }}#{{ nc_resource_subnet }}#{{ nc_instance_regionid }}02'
   subnet03Name: '#{{ networkResourceNamePrefix }}#{{ nc_resource_subnet }}#{{ nc_instance_regionid }}03'
 }

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -90,7 +90,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'feature/debug-calico-backup'
+      branch: 'main'
     }
     kustomizations: {
       timeoutInSeconds: 600

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -89,7 +89,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'main'
+      branch: 'feature/debug'
     }
     kustomizations: {
       timeoutInSeconds: 600

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -109,6 +109,13 @@ param appConfig = {
   managedIdentityName: '#{{ acManagedIdentityName }}'
 }
 
+param keyvaultFwCertificate = {
+  subscriptionId: '#{{ ssvSubscriptionId }}'
+  resourceGroup: '#{{ ssvSharedResourceGroup }}'
+  keyVaultName: '#{{ ssvPlatformKeyVaultName }}'
+  secretName: 'AKS-Defra-Egress-Firewall-Cert-01'
+}
+
 param keyVault = {
   resourceGroup: '#{{ servicesResourceGroup }}'
   keyVaultName: '#{{ infraResourceNamePrefix }}#{{ nc_resource_keyvault }}#{{ nc_instance_regionid }}02'

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -90,7 +90,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'main'
+      branch: 'feature/debug-calico-backup'
     }
     kustomizations: {
       timeoutInSeconds: 600


### PR DESCRIPTION
We need to only allow ingress from the AKS Internal LoadBalancer subnet.  This change will pass the AKS ILB Subnet Range to Flux as a post build variable, so we can use it in a Calico Network Policy.

nodeLabels have been removed because we are now using an already available label (**kubernetes.azure.com/mode system**) for both nginx and Calico API server, to ensure pods are only deployed to System nodes.

[AB#248312](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/248312)

# Testing
Tested against SND1 ensuring Cluster and Applications are still functioning as normal after Network policies have been applied.  We also did additional testing by spinning up pods in application namespaces and ensuring pod to pod communication within the cluster is allowed and communication from one application namespace to another isn't allowed.

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcXJsNDFqdzBqdWZiaWF1NnZ2cGtqNmF2ZWt6dmYwMXZlM2p2NHNyeCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/077i6AULCXc0FKTj9s/giphy.gif)