### PR TITLE
333875: Comment out event-hub-secret-rbac from pipeline

### DIFF
--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -249,10 +249,10 @@ extends:
                         -Label "adp-platform"
                         -AppConfigName $(infraResourceNamePrefix)$(nc_resource_appconfiguration)$(nc_instance_regionid)01
                         -ConfigData '[{"key": "CLUSTER_OIDC_ISSUER_URL", "value": "$(clusterOidc)", "label": "adp-platform", "contentType": "text/plain" }]'
-                - name: event-hub-secret-rbac
-                  serviceConnectionVariableName: ssvServiceConnection
-                  path: infra/core/env/event-hub
-                  resourceGroupName: $(ssvInfraSharedRg)
+                # - name: event-hub-secret-rbac
+                #   serviceConnectionVariableName: ssvServiceConnection
+                #   path: infra/core/env/event-hub
+                #   resourceGroupName: $(ssvInfraSharedRg)
               - ${{ if eq(variables.IsManagedClusterFluxServicesSSHKeys, true) }}:
                 - name: Flux Services SSH Keys
                   serviceConnectionVariableName: ssvServiceConnection


### PR DESCRIPTION
# **What this PR does / why we need it**:
There is currently a dependency on Production resources (EventHub,KeyVault) being in place to send notifications from Dev, Tst, Pre and Prd Clusters.  This is causing the pipeline platform-adp-core-env pipeline to fail after the Cluster is deployed.

Failure example below
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=522193&view=results

We are temporarily commenting out the section that has dependencies and will revisit this as part of the Flux Notification Stories

[AB#333875](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/333875)

# **Special notes for your reviewer**

# Testing

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
