### PR TITLE
333875: Remove eventhub key value from appconfig deployment

### DIFF
--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -202,11 +202,5 @@
     "value": "ADO-DefraGovUK-AAD-ADP-#{{ ssvEnvironment }}#{{ nc_shared_instance }}",
     "label": "adp-platform",
     "contentType": "text/plain"
-  },
-  {
-    "key": "address",
-    "value": "{\"uri\":\"https://#{{ ssvInfraKeyVault }}.vault.azure.net/secrets/#{{ environment }}#{{ nc_instance_regionid }}0#{{ environmentId }}-ADP-EVENTHUB-CONNECTION\"}",
-    "label": "adp-platform",
-    "contentType": "text/plain"
   }
 ]


### PR DESCRIPTION
There is currently a dependency on Production resources (EventHub,KeyVault) being in place to send notifications from Dev, Tst, Pre and Prd Clusters. This is causing the pipeline platform-adp-core-env pipeline to fail after the Cluster is deployed.

Failure example below
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=522193&view=results

We need to remove the address key value from app config to prevent any issues with the Platform config map being created on the Cluster

[AB#333875](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/333875)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
