### PR TITLE
373154: Fix bug 'Get Azure Monitor Workspace Resource IDs to link to Grafana Dashboard Task failing'

### DIFF
--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -184,7 +184,8 @@ extends:
                     - displayName: Get Azure Monitor Workspace Resource IDs to link to Grafana Dashboard
                       scriptPath: infra/core/env/scripts/Get-WorkspaceResourceIds.ps1
                       serviceConnectionVariableName: ssvServiceConnection
-                      type: AzurePowerShell
+                      type: AzureCLI
+                      azureCLIScriptType: pscore
                       scriptArguments: >
                         -ResourceGroupName $(ssvSharedResourceGroup)
                         -GrafanaName $(ssvInfraResourceNamePrefix)$(nc_resource_grafana)$(nc_shared_instance_regionid)01


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Fix bug 'Get Azure Monitor Workspace Resource IDs to link to Grafana Dashboard Task failing'
Relates to ADO Work Item [AB#373154](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/373154)

This is an issue with the below Azure Powershell command. This is a quick fix using Azure CLI command.
![image](https://github.com/DEFRA/adp-infrastructure-core/assets/89150034/504d0bc7-eb67-4687-83a1-daecfd13d93e)


# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
