### PR TITLE
364244: Remove Private Endpoints in SND3 Storage Accounts in DEFRA Dev Tenant

### DIFF
--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -64,7 +64,8 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: main
+      #ref: main
+      ref: sm/337709/RemovePrivateEndpoints
       
 variables:
   - name: IsAll

--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -64,8 +64,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      #ref: main
-      ref: sm/337709/RemovePrivateEndpoints
+      ref: main      
       
 variables:
   - name: IsAll

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -205,7 +205,7 @@
   },
   {
     "key": "ENABLE_PRIVATE_ENDPOINT",
-    "value": "#{{ lower(enablePrivateEndpoint) }}",
+    "value": "disable",
     "label": "adp-platform",
     "contentType": "text/plain"
   }

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -202,5 +202,11 @@
     "value": "ADO-DefraGovUK-AAD-ADP-#{{ ssvEnvironment }}#{{ nc_shared_instance }}",
     "label": "adp-platform",
     "contentType": "text/plain"
+  },
+  {
+    "key": "ENABLE_PRIVATE_ENDPOINT",
+    "value": "#{{ lower(enablePrivateEndpoint) }}",
+    "label": "adp-platform",
+    "contentType": "text/plain"
   }
 ]

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -205,7 +205,7 @@
   },
   {
     "key": "ENABLE_PRIVATE_ENDPOINT",
-    "value": "#{{ lower(enablePrivateEndpoint) }}",
+    "value": "false",
     "label": "adp-platform",
     "contentType": "text/plain"
   }

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -205,7 +205,7 @@
   },
   {
     "key": "ENABLE_PRIVATE_ENDPOINT",
-    "value": "disable",
+    "value": "#{{ lower(enablePrivateEndpoint) }}",
     "label": "adp-platform",
     "contentType": "text/plain"
   }

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -205,7 +205,7 @@
   },
   {
     "key": "ENABLE_PRIVATE_ENDPOINT",
-    "value": "true",
+    "value": "false",
     "label": "adp-platform",
     "contentType": "text/plain"
   }

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -205,7 +205,7 @@
   },
   {
     "key": "ENABLE_PRIVATE_ENDPOINT",
-    "value": "true",
+    "value": "disable",
     "label": "adp-platform",
     "contentType": "text/plain"
   }

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -205,7 +205,7 @@
   },
   {
     "key": "ENABLE_PRIVATE_ENDPOINT",
-    "value": "false",
+    "value": "true",
     "label": "adp-platform",
     "contentType": "text/plain"
   }

--- a/infra/core/env/app-configuration/config-data/config-data.json
+++ b/infra/core/env/app-configuration/config-data/config-data.json
@@ -204,6 +204,12 @@
     "contentType": "text/plain"
   },
   {
+    "key": "address",
+    "value": "{\"uri\":\"https://#{{ ssvEventHubConnectionStringKeyVault }}.vault.azure.net/secrets/#{{ environment }}#{{ nc_instance_regionid }}0#{{ environmentId }}-ADP-EVENTHUB-CONNECTION\"}",
+    "label": "adp-platform",
+    "contentType": "text/plain"
+  },
+  {
     "key": "ENABLE_PRIVATE_ENDPOINT",
     "value": "#{{ lower(enablePrivateEndpoint) }}",
     "label": "adp-platform",

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -90,7 +90,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'sm/337709/RemovePrivateEndpoints'
+      branch: 'main'
     }
     kustomizations: {
       timeoutInSeconds: 600

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -90,7 +90,7 @@ param fluxConfig = {
       syncIntervalInSeconds: 300
       timeoutInSeconds: 180
       url: 'https://github.com/DEFRA/adp-flux-core'
-      branch: 'main'
+      branch: 'sm/337709/RemovePrivateEndpoints'
     }
     kustomizations: {
       timeoutInSeconds: 600


### PR DESCRIPTION
[AB#364244](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/364244)

# **What this PR does / why we need it**:
Add platform variables and value to cluster (ENABLE_PRIVATE_ENDPOINT)
It will remove/restrict to create private end points for the storage accounts in SND environments(DefraDev Tenant).
No manual step required for adding the private IP to the DNS Zone and will not block teams using SND environments

# **Special notes for your reviewer**
A flag as "enablePrivateEndpoint" is passed from the patch.yaml of each environment (snd,dev, tst, pre and prd).
For SND environment the flag enablePrivateEndpoint is false
For other environments (dev, tst, pre and prd) enablePrivateEndpoint is true

This flag enablePrivateEndpoint being used in adp-aso-helm-library to conditionally create storage accounts with private endpoints.

# Testing
Any relevant testing information and pipeline runs.
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=550162&view=results
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=549373&view=results

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# **How does this PR make you feel**: