### PR TITLE
328599: Fix SND4 service connection name

### DIFF
--- a/.azuredevops/deploy-platform-build-agent.yaml
+++ b/.azuredevops/deploy-platform-build-agent.yaml
@@ -71,7 +71,7 @@ extends:
         azureRegions:
           primary: 'UKSouth'
       - name: 'snd4'
-        serviceConnection: AZD-ADP-SND4-VMSS
+        serviceConnection: AZR-ADP-SND4
         dependsOn: 'snd3'
         deploymentBranches:
           - 'refs/heads/main'


### PR DESCRIPTION
# **What this PR does / why we need it**:
The build agent service connection name was wrong.  This Pr corrects the name.

[AB#328599](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/328599)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
