### PR TITLE
296228: Support for TLS Version 1.2 ASB

### DIFF
--- a/infra/core/env/service-bus/namespace.bicep
+++ b/infra/core/env/service-bus/namespace.bicep
@@ -35,14 +35,16 @@ var serviceBusPrivateEndpointTags = {
   Tier: 'Shared'
 }
 
-module serviceBusResource 'br/SharedDefraRegistry:service-bus.namespace:0.5.3' = {
+module serviceBusResource 'br/SharedDefraRegistry:service-bus.namespace:0.5.16' = {
   name: 'service-bus-${deploymentDate}'
   params: {
     name: serviceBus.namespaceName
     skuName: serviceBus.skuName
     location: location
-    diagnosticWorkspaceId: ''
-    lock: 'CanNotDelete'
+    minimumTlsVersion:'1.2'
+    lock: {
+      kind:'CanNotDelete'
+    }
     networkRuleSets: {
       publicNetworkAccess: 'Disabled'
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
[AB#296288](https://dev.azure.com/defragovuk/DEFRA-FFC/_workitems/edit/296228)

This PR adds support for TLS Version 1.2 for Azure Service Bus.  It upgrades the resource module to get latest api for service bus as namespaces created using api-version prior to 2022-01-01-preview will have 1.0 as the value for MinimumTlsVersion 

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
