### PR TITLE
353142: Grant read access to Platform team on the flux notifications database in PRE

### DIFF
--- a/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRE.json
+++ b/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRE.json
@@ -23,6 +23,9 @@
                 ]
             },
             "Members": {
+                "groups" : [
+                    "AAG-Users-ADP-PlatformEngineers"
+                ],
                 "serviceprincipals" : [
                     "#{{ adoCallbackApiManagedIdentity }}"
                 ]


### PR DESCRIPTION
# **What this PR does / why we need it**:
In order for us to test flux notification and the callback api, we need to have visibility to the flux notifications database in PRE.  This PR will grant the Platform Team reader access to the database.

[AB#353142](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/353142)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
