### PR TITLE
353142: Add correct service principal as the owner of the flux-api groups

### DIFF
--- a/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRD.json
+++ b/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRD.json
@@ -5,7 +5,7 @@
             "description": "Azure AD Access group with Write permissions to the flux_notifications_db database.",
             "Owners": {
                 "serviceprincipals" : [
-                    "ADO-DefraGovUK-AAD-ADP-SSV5"
+                    "ADO-DefraGovUK-AAD-CDO-SSV5"
                 ]
             },
             "Members": {
@@ -19,7 +19,7 @@
             "description": "Azure AD Access group with Reader permissions to the flux_notifications_db database.",
             "Owners": {
                 "serviceprincipals" : [
-                    "ADO-DefraGovUK-AAD-ADP-SSV5"
+                    "ADO-DefraGovUK-AAD-CDO-SSV5"
                 ]
             },
             "Members": {

--- a/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRE.json
+++ b/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRE.json
@@ -5,7 +5,7 @@
             "description": "Azure AD Access group with Write permissions to the flux_notifications_db database.",
             "Owners": {
                 "serviceprincipals" : [
-                    "ADO-DefraGovUK-AAD-ADP-SSV5"
+                    "ADO-DefraGovUK-AAD-CDO-SSV5"
                 ]
             },
             "Members": {
@@ -19,7 +19,7 @@
             "description": "Azure AD Access group with Reader permissions to the flux_notifications_db database.",
             "Owners": {
                 "serviceprincipals" : [
-                    "ADO-DefraGovUK-AAD-ADP-SSV5"
+                    "ADO-DefraGovUK-AAD-CDO-SSV5"
                 ]
             },
             "Members": {

--- a/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRE.json
+++ b/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRE.json
@@ -23,6 +23,9 @@
                 ]
             },
             "Members": {
+                "groups" : [
+                    "AAG-Users-ADP-PlatformEngineers"
+                ],
                 "serviceprincipals" : [
                     "#{{ adoCallbackApiManagedIdentity }}"
                 ]


### PR DESCRIPTION
# **What this PR does / why we need it**:
The owner of the flux-api groups was set incorrectly.  This PR adds the correct owner.  The pipeline will fail until the owner is first added manually by the O365 team.

[AB#353142](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/353142)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
