### PR TITLE
383710: Pass in Postgres admin user from common vars

### DIFF
--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -65,7 +65,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: aa/postgresAdminUser     
+      ref: main     
       
 variables:
   - name: IsAll

--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -65,7 +65,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: main     
+      ref: aa/postgresAdminUser     
       
 variables:
   - name: IsAll

--- a/infra/core/env/postgre-sql/flexible-server.bicep
+++ b/infra/core/env/postgre-sql/flexible-server.bicep
@@ -1,4 +1,4 @@
-@description('Required. The object of the PostgreSQL Flexible Server. The object must contain name,storageSizeGB and highAvailability properties.')
+@description('Required. The object of the PostgreSQL Flexible Server. The object must contain name,storageSizeGB,highAvailability and administratorLogin properties.')
 param server object
 
 @description('Required. The parameter object for the virtual network. The object must contain the name,skuName,resourceGroup and subnetPostgreSql values.')
@@ -33,9 +33,6 @@ param createdDate string = utcNow('yyyy-MM-dd')
 
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
-
-@description('Optional. The administrator login name of a server. Can only be specified when the PostgreSQL server is being created.')
-param administratorLogin string = 'adpAdminUser1'
 
 param guidValue string = guid(deploymentDate)
 var administratorLoginPassword  = substring(replace(replace(guidValue, '.', '-'), '-', ''), 0, 20)
@@ -95,7 +92,7 @@ module flexibleServerDeployment 'br/avm:db-for-postgre-sql/flexible-server:0.1.1
   name: 'postgre-sql-flexible-server-${deploymentDate}'
   params: {
     name: toLower(server.name)
-    administratorLogin: administratorLogin
+    administratorLogin: server.administratorLogin
     administratorLoginPassword : administratorLoginPassword
     storageSizeGB: server.storageSizeGB
     highAvailability: server.highAvailability
@@ -146,7 +143,7 @@ module keyVaultSecrets '.bicep/kv-secrets.bicep' = {
   params: {
     keyVaultName: applicationKeyVault.name
     flexibleServerName: flexibleServerDeployment.outputs.name
-    administratorLogin: administratorLogin
+    administratorLogin: server.administratorLogin
     administratorLoginPassword: administratorLoginPassword
   }
 }

--- a/infra/core/env/postgre-sql/flexible-server.bicepparam
+++ b/infra/core/env/postgre-sql/flexible-server.bicepparam
@@ -7,7 +7,7 @@ param server = {
   skuName: '#{{ postgreSqlSkuName }}'
   highAvailability: '#{{ postgreSqlHighAvailability }}'
   availabilityZone: '#{{ postgreSqlAvailabilityZone }}'
-  administratorLogin: '#{{ postgreSqlAdministratorLogin }}'
+  administratorLogin: '#{{ postgreSqlAdministratorUserName }}'
 }
 param vnet = {
   name: '#{{ virtualNetworkName }}'

--- a/infra/core/env/postgre-sql/flexible-server.bicepparam
+++ b/infra/core/env/postgre-sql/flexible-server.bicepparam
@@ -7,6 +7,7 @@ param server = {
   skuName: '#{{ postgreSqlSkuName }}'
   highAvailability: '#{{ postgreSqlHighAvailability }}'
   availabilityZone: '#{{ postgreSqlAvailabilityZone }}'
+  administratorLogin: '#{{ postgreSqlAdministratorLogin }}'
 }
 param vnet = {
   name: '#{{ virtualNetworkName }}'


### PR DESCRIPTION
# **What this PR does / why we need it**:

The postgres user should be different for all environments and not easy to guess.  The usernames for SND1,2 and 3 where previously already set either manually or via automation.  We have decided to leave those as they are for now, so we don't have tear down and rebuid the flexible server.

[AB#383710](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/383710)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=577213&view=logs&s=aee76c8a-1d8b-5149-1924-86de92a850c9

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# **How does this PR make you feel**:
![gif]([https://giphy.com/)
