### PR TITLE
383711: Contributor permission to AKS cluster control MI and Kubelet MI

### DIFF
--- a/infra/core/env/managed-cluster/aks-cluster.bicep
+++ b/infra/core/env/managed-cluster/aks-cluster.bicep
@@ -118,6 +118,8 @@ var systemNodePool = {
   ]
 }
 
+var contributorRoleId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
 module managedIdentity 'br/SharedDefraRegistry:managed-identity.user-assigned-identity:0.4.3' = {
   name: 'aks-cluster-mi-${deploymentDate}'
   params: {
@@ -481,6 +483,30 @@ module clusterRoleAssignment '.bicep/cluster-rbac.bicep' = {
   params: {
     clusterName: cluster.name
     principalId: cluster.adminAadGroupObjectId
+  }
+}
+
+module kubeletMIContributorRoleAssignment '.bicep/subscription-rbac.bicep' = {
+  name: 'kubeletmi-subscription-contributor-${deploymentDate}'
+  scope: subscription()
+  dependsOn: [
+    deployAKS
+  ]
+  params: {
+    principalId: deployAKS.outputs.kubeletidentityObjectId
+    roleDefinitionId: contributorRoleId
+  }
+}
+
+module controlPlaneMIContributorRoleAssignment '.bicep/subscription-rbac.bicep' = {
+  name: 'aks-cluster-subscription-contributor-${deploymentDate}'
+  scope: subscription()
+  dependsOn: [
+    managedIdentity
+  ]
+  params: {
+    principalId: managedIdentity.outputs.principalId
+    roleDefinitionId: contributorRoleId
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
AKS ' {env}-cluster-control-plane' and Kubelet identity require the necessary permissions to create and mount persistent volumes such as Azure disks and File Share. 

Contributor permissions at the subscription level will grant access to all teams for their storage accounts hosting the file share or Azure Disk.

Relates to ADO Work Item [AB#383711](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/383711)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
