### PR TITLE
390735: Allow ADP Platform engineers  read acces to flux notifications db

### DIFF
--- a/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRD.json
+++ b/infra/core/env-shared/flux-notification/config/aad-groups/fluxApiAADGroups.SSV_PRD.json
@@ -23,6 +23,9 @@
                 ]
             },
             "Members": {
+                "groups" : [
+                    "AAG-Users-ADP-PlatformEngineers"
+                ],
                 "serviceprincipals" : [
                     "#{{ adoCallbackApiManagedIdentity }}"
                 ]


### PR DESCRIPTION
# **What this PR does / why we need it**:

In order to test the Flux Notification solution in Production the ADP Platform team require reader permissions on the Flux Notifications database.  This will also be required for troubleshooting any issues with the Flux Notification in the future.

[AB#390735](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/390735)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
