### PR TITLE
395074: Filter out fluxconfig-agent and fluxconfig-controller pods for the KubePodContainerRestart alert

### DIFF
--- a/infra/core/env/observability/prometheus-alerts.bicepparam
+++ b/infra/core/env/observability/prometheus-alerts.bicepparam
@@ -51,7 +51,7 @@ param alerts = [
   }
   {
     name: 'KubePodContainerRestart'
-    expression: 'sum by (namespace, controller, container, cluster)(increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"#{{ clusterNamespacesToMonitor }}"}[1h])* on(namespace, pod, cluster) group_left(controller) label_replace(kube_pod_owner, "controller", "$1", "owner_name", "(.*)")) > 0'
+    expression: 'sum by (namespace, controller, container, cluster)(increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"#{{ clusterNamespacesToMonitor }}", pod!~"fluxconfig-.*"}[1h])* on(namespace, pod, cluster) group_left(controller) label_replace(kube_pod_owner, "controller", "$1", "owner_name", "(.*)")) > 0'
     description: 'Pod container restarted in the last 1 hour.'
     firedTimePeriod: 'PT15M'
     timeToResolve: 'PT10M'


### PR DESCRIPTION
# **What this PR does / why we need it**:
Filter out the KubePodContainerRestart alert for the fluxconfig-agent and fluxconfig-controller pods to reduce noise in the alerting channels.

The fluent-bit container in the fluxconfig-agent and fluxconfig-controller pods is restarting numerous times throughout the day in all environments.  This will result in a lot of alerts which will cause noise and could lead to us missing other alerts.  There is already a bug raised for the fluent-bit container https://github.com/Azure/AKS/issues/4358.  We will also raise a separate ticket with Microsoft in the hope it will speed up a resolution to the pod container restart issue.  We can enable the alert for the fluxconfig-agent and fluxconfig-controller pods once we have a resolution.

[AB#395074](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/395074)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=594935&view=results

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
