### PR TITLE
341945: Configure Delete Locks for Environments

### DIFF
--- a/.azuredevops/deploy-platform-bootstrap-env-shared.yaml
+++ b/.azuredevops/deploy-platform-bootstrap-env-shared.yaml
@@ -50,7 +50,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: main
+      ref: aa/disableLocksLowerEnvironments
 
 variables:
   - name: IsAll

--- a/.azuredevops/deploy-platform-bootstrap-env.yaml
+++ b/.azuredevops/deploy-platform-bootstrap-env.yaml
@@ -42,7 +42,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: main
+      ref: aa/disableLocksLowerEnvironments
 
 variables:
   - name: IsAll

--- a/.azuredevops/deploy-platform-core-env-shared.yaml
+++ b/.azuredevops/deploy-platform-core-env-shared.yaml
@@ -47,7 +47,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref:  main
+      ref: aa/disableLocksLowerEnvironments
       
 variables:
   - name: IsAll

--- a/.azuredevops/deploy-platform-core-env.yaml
+++ b/.azuredevops/deploy-platform-core-env.yaml
@@ -70,7 +70,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: refs/tags/1.0.0-latest
+      ref: aa/disableLocksLowerEnvironments
       
 variables:
   - name: IsAll

--- a/.azuredevops/deploy-platform-sec-env.yaml
+++ b/.azuredevops/deploy-platform-sec-env.yaml
@@ -41,7 +41,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref:  main
+      ref: aa/disableLocksLowerEnvironments
 
 variables:
   - name: IsAll

--- a/infra/bootstrap/env-shared/container-registry/platform-container-registry.bicep
+++ b/infra/bootstrap/env-shared/container-registry/platform-container-registry.bicep
@@ -10,6 +10,9 @@ param environment string
 @description('Optional. Enable a single data endpoint per region for serving data. Not relevant in case of disabled public access. Note, requires the \'acrSku\' to be \'Premium\'.')
 param dataEndpointEnabled bool = false
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -35,7 +38,7 @@ module registry 'br/SharedDefraRegistry:container-registry.registry:0.5.5' = {
   params: {
     name: containerRegistry.name
     acrSku: containerRegistry.acrSku
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     retentionPolicyDays: int(containerRegistry.retentionPolicyDays)
     softDeletePolicyDays: int(containerRegistry.softDeletePolicyDays)
     tags: union(defaultTags, containerRegistryTags)

--- a/infra/bootstrap/env-shared/container-registry/platform-container-registry.parameters.json
+++ b/infra/bootstrap/env-shared/container-registry/platform-container-registry.parameters.json
@@ -15,6 +15,9 @@
     },
     "environment": {
       "value": "#{{ environment }}"
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/bootstrap/env-shared/event-hub/namespace.bicep
+++ b/infra/bootstrap/env-shared/event-hub/namespace.bicep
@@ -7,6 +7,9 @@ param eventHubNamespace object
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -42,9 +45,9 @@ module eventHubNamespaceResource 'br/SharedDefraRegistry:event-hub.namespace:0.5
     name: eventHubNamespace.name
     skuName: 'Standard'
     location: location
-    lock: {
+    lock: resourceLockEnabled ? {
       kind: 'CanNotDelete'
-    }
+    } : null
     tags: union(tags, eventHubNamespaceTags)
     networkRuleSets: {
       defaultAction: 'Deny'

--- a/infra/bootstrap/env-shared/event-hub/namespace.bicepparam
+++ b/infra/bootstrap/env-shared/event-hub/namespace.bicepparam
@@ -14,3 +14,5 @@ param vnet = {
   resourceGroup: '#{{ ssvVirtualNetworkResourceGroup }}'
   subnetPrivateEndpoints: '#{{ networkResourceNamePrefix }}#{{ nc_resource_subnet }}#{{ nc_instance_regionid }}01'
 }
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/bootstrap/env-shared/flexible-server-zone/flexible-server-zone.bicep
+++ b/infra/bootstrap/env-shared/flexible-server-zone/flexible-server-zone.bicep
@@ -7,6 +7,9 @@ param privateDnsZone string
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 
@@ -33,7 +36,8 @@ var dnsVnetLinksTags = {
 module privateDnsZoneModule 'br/SharedDefraRegistry:network.private-dns-zone:0.5.2' = {
   name: 'postgresql-private-dns-zone-${deploymentDate}'
   params: {
-   name: privateDnsZoneName  
+   name: privateDnsZoneName
+   lock: resourceLockEnabled ? 'CanNotDelete' : null 
    tags: union(tags, dnsTags)
    virtualNetworkLinks: [
     {

--- a/infra/bootstrap/env-shared/flexible-server-zone/flexible-server-zone.bicepparam
+++ b/infra/bootstrap/env-shared/flexible-server-zone/flexible-server-zone.bicepparam
@@ -8,3 +8,5 @@ param vnet = {
 param privateDnsZone = '#{{ postgreSqlPvtDnsZone }}'
 
 param environment = '#{{ environment }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/bootstrap/env-shared/key-vault/platform-apps-key-vault.bicep
+++ b/infra/bootstrap/env-shared/key-vault/platform-apps-key-vault.bicep
@@ -26,6 +26,8 @@ param platformUserGroupId string
 @description('Required. The parameter object for the application insights.')
 param appInsights object
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 
 var roleAssignments = [
   {
@@ -72,7 +74,7 @@ module vaults 'br/SharedDefraRegistry:key-vault.vault:0.5.3' = {
     name: keyVault.name
     tags: union(defaultTags, keyVaultTags)
     vaultSku: keyVault.skuName
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     enableRbacAuthorization: true    
     enableSoftDelete: bool(keyVault.enableSoftDelete)
     enablePurgeProtection: bool(keyVault.enablePurgeProtection)

--- a/infra/bootstrap/env-shared/key-vault/platform-key-vault.bicep
+++ b/infra/bootstrap/env-shared/key-vault/platform-key-vault.bicep
@@ -28,6 +28,9 @@ param roleAssignments array
   ])
 param skuName string = 'premium'
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 
@@ -49,6 +52,7 @@ module vaults 'br/SharedDefraRegistry:key-vault.vault:0.5.3' = {
     name: keyVaultName
     tags: tags
     vaultSku: skuName
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     enableRbacAuthorization: true    
     enableSoftDelete: enableSoftDelete
     enablePurgeProtection: enablePurgeProtection

--- a/infra/bootstrap/env-shared/key-vault/platform-key-vault.parameters.json
+++ b/infra/bootstrap/env-shared/key-vault/platform-key-vault.parameters.json
@@ -36,6 +36,9 @@
         },
         "softDeleteRetentionInDays": {
             "value": #{{ keyvaultSoftDeleteRetentionInDays }}
+        },
+        "resourceLockEnabled": {
+            "value": #{{ resourceLockEnabled }}
         }
     }
 }

--- a/infra/bootstrap/env-shared/key-vault/subenv1-params/platform-apps-key-vault.bicepparam
+++ b/infra/bootstrap/env-shared/key-vault/subenv1-params/platform-apps-key-vault.bicepparam
@@ -27,3 +27,5 @@ param appInsights = {
   name: '#{{ applicationInsightsName }}'
   resourceGroup: '#{{ ssvSharedResourceGroup }}'
 }
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/bootstrap/env-shared/key-vault/subenv2-params/platform-apps-key-vault.bicepparam
+++ b/infra/bootstrap/env-shared/key-vault/subenv2-params/platform-apps-key-vault.bicepparam
@@ -27,3 +27,5 @@ param appInsights = {
   name: '#{{ applicationInsightsName }}'
   resourceGroup: '#{{ ssvSharedResourceGroup }}'
 }
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/bootstrap/env-shared/log-analytics-workspace/log-analytics-workspace.bicepparam
+++ b/infra/bootstrap/env-shared/log-analytics-workspace/log-analytics-workspace.bicepparam
@@ -8,3 +8,5 @@ param logAnalytics = {
 param location = '#{{ location }}'
 
 param environment = '#{{ environment }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/bootstrap/env-shared/network/network-security-group.bicep
+++ b/infra/bootstrap/env-shared/network/network-security-group.bicep
@@ -9,6 +9,8 @@ param environment string
 param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 
 var commonTags = {
   Location: location
@@ -22,7 +24,7 @@ module networksecuritygroup 'br/SharedDefraRegistry:network.network-security-gro
   name: '${nsg.name}-${deploymentDate}'
   params: {
     name: nsg.name
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     location: location
     tags: union(tags, { Purpose: nsg.purpose})
     securityRules: nsg.securityRules 

--- a/infra/bootstrap/env-shared/network/network-security-group.bicepparam
+++ b/infra/bootstrap/env-shared/network/network-security-group.bicepparam
@@ -1614,3 +1614,5 @@ param nsgList = [
     ]
   }
 ]
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/bootstrap/env-shared/network/route-table.bicep
+++ b/infra/bootstrap/env-shared/network/route-table.bicep
@@ -13,6 +13,8 @@ param environment string
 param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 
 var commonTags = {
   Location: location
@@ -26,7 +28,7 @@ module route 'br/SharedDefraRegistry:network.route-table:0.4.2' = {
   name: 'route-table-${deploymentDate}'
   params: {
     name: routeTable.name
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     location: location
     tags: tags
     disableBgpRoutePropagation: true

--- a/infra/bootstrap/env-shared/network/route-table.bicepparam
+++ b/infra/bootstrap/env-shared/network/route-table.bicepparam
@@ -19,3 +19,5 @@ param routes = [
 param location = '#{{ location }}'
 
 param environment = '#{{ environment }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/common/network/network-security-group.bicep
+++ b/infra/common/network/network-security-group.bicep
@@ -5,6 +5,8 @@ param nsgList array = []
 param location string
 @description('Required. Environment name.')
 param environment string
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
@@ -22,7 +24,7 @@ module networksecuritygroup 'br/SharedDefraRegistry:network.network-security-gro
   name: '${nsg.name}-${deploymentDate}'
   params: {
     name: nsg.name
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     location: location
     tags: union(tags, { Purpose: nsg.purpose})
     securityRules: nsg.securityRules 

--- a/infra/common/network/network-security-group.parameters.json
+++ b/infra/common/network/network-security-group.parameters.json
@@ -1064,6 +1064,9 @@
                     ]
                 }
             ]
+        },
+        "resourceLockEnabled": {
+            "value": #{{ resourceLockEnabled }}
         }
     }
 }

--- a/infra/common/network/route-table.bicep
+++ b/infra/common/network/route-table.bicep
@@ -7,6 +7,8 @@ param routeTable object
 param location string
 @description('Required. Environment name.')
 param environment string
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
@@ -24,7 +26,7 @@ module route 'br/SharedDefraRegistry:network.route-table:0.4.2' = {
   name: 'route-table-${deploymentDate}'
   params: {
     name: routeTable.name
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     location: location
     tags: tags
     disableBgpRoutePropagation: true

--- a/infra/common/network/route-table.parameters.json
+++ b/infra/common/network/route-table.parameters.json
@@ -13,6 +13,9 @@
     },
     "environment": {
       "value": "#{{ environment }}"
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/common/network/virtual-network.bicep
+++ b/infra/common/network/virtual-network.bicep
@@ -11,6 +11,8 @@ param subnets array
 param location string
 @description('Required. Environment name.')
 param environment string
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
@@ -29,7 +31,7 @@ module virtualNetwork 'br/SharedDefraRegistry:network.virtual-network:0.4.2' = {
   params: {
     name: vnet.name
     location: location
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     tags: tags
     enableDefaultTelemetry: true
     addressPrefixes: vnet.addressPrefixes

--- a/infra/common/network/virtual-network.parameters.json
+++ b/infra/common/network/virtual-network.parameters.json
@@ -102,6 +102,9 @@
     },
     "environment": {
       "value": "#{{ environment }}"
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/common/operational-insights/log-analytics-workspace.bicep
+++ b/infra/common/operational-insights/log-analytics-workspace.bicep
@@ -33,10 +33,7 @@ module logAnalyticsWorkspaceResource 'br/SharedDefraRegistry:operational-insight
     name: logAnalytics.name
     location: location
     skuName: logAnalytics.skuName
-    lock: resourceLockEnabled ? {
-      kind: 'CanNotDelete'
-      name: 'CanNotDelete'
-    } : null
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     tags: tags
   }
 }

--- a/infra/common/operational-insights/log-analytics-workspace.bicep
+++ b/infra/common/operational-insights/log-analytics-workspace.bicep
@@ -7,6 +7,9 @@ param location string = resourceGroup().location
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -30,6 +33,10 @@ module logAnalyticsWorkspaceResource 'br/SharedDefraRegistry:operational-insight
     name: logAnalytics.name
     location: location
     skuName: logAnalytics.skuName
+    lock: resourceLockEnabled ? {
+      kind: 'CanNotDelete'
+      name: 'CanNotDelete'
+    } : null
     tags: tags
   }
 }

--- a/infra/common/operational-insights/log-analytics-workspace.bicepparam
+++ b/infra/common/operational-insights/log-analytics-workspace.bicepparam
@@ -8,3 +8,5 @@ param logAnalytics = {
 param location = '#{{ location }}'
 
 param environment = '#{{ environment }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env-shared/adp-portal-api/managed-identity/managed-identity.bicep
+++ b/infra/core/env-shared/adp-portal-api/managed-identity/managed-identity.bicep
@@ -31,6 +31,9 @@ param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Application Insights object.')
 param appInsights object
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 
 var customTags = {
   Location: location
@@ -51,7 +54,7 @@ module managedIdentities 'br/SharedDefraRegistry:managed-identity.user-assigned-
   params: {
     name: managedIdentity.name
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     roleAssignments: roleAssignments
   }
 }

--- a/infra/core/env-shared/adp-portal-api/managed-identity/managed-identity.bicepparam
+++ b/infra/core/env-shared/adp-portal-api/managed-identity/managed-identity.bicepparam
@@ -36,3 +36,5 @@ param appInsights = {
   resourceGroup: '#{{ ssvSharedResourceGroup }}'
   subscriptionId: '#{{ subscriptionId }}'
 }
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env-shared/adp-portal/managed-identity/managed-identity.bicep
+++ b/infra/core/env-shared/adp-portal/managed-identity/managed-identity.bicep
@@ -25,6 +25,9 @@ param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Application Insights object.')
 param appInsights object
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var customTags = {
   Location: location
   CreatedDate: createdDate
@@ -44,7 +47,7 @@ module managedIdentities 'br/SharedDefraRegistry:managed-identity.user-assigned-
   params: {
     name: managedIdentity.name
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     roleAssignments: roleAssignments
   }
 }

--- a/infra/core/env-shared/adp-portal/managed-identity/managed-identity.bicepparam
+++ b/infra/core/env-shared/adp-portal/managed-identity/managed-identity.bicepparam
@@ -25,3 +25,5 @@ param appInsights = {
   resourceGroup: '#{{ ssvSharedResourceGroup }}'
   subscriptionId: '#{{ subscriptionId }}'
 }
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env-shared/adp-portal/storage-account/storage-account.bicep
+++ b/infra/core/env-shared/adp-portal/storage-account/storage-account.bicep
@@ -29,6 +29,9 @@ param createdDate string = utcNow('yyyy-MM-dd')
 @description('Required. The name of the key vault where the secrets will be stored.')
 param keyvaultName string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var customTags = {
   Location: location
   CreatedDate: createdDate
@@ -55,7 +58,7 @@ module storageAccounts 'br/SharedDefraRegistry:storage.storage-account:0.5.3' = 
     name: toLower(storageAccount.name)
     tags: union(defaultTags, storageAccountTags)
     skuName: storageAccount.skuName
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     kind: kind
     networkAcls: {
       bypass: 'AzureServices'

--- a/infra/core/env-shared/adp-portal/storage-account/storage-account.bicepparam
+++ b/infra/core/env-shared/adp-portal/storage-account/storage-account.bicepparam
@@ -18,3 +18,5 @@ param keyvaultName = '#{{ ssvInfraKeyVault }}'
 param environment = '#{{ environment }}'
 
 param location = '#{{ location }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env-shared/container-apps-env/container-apps-env.bicep
+++ b/infra/core/env-shared/container-apps-env/container-apps-env.bicep
@@ -28,6 +28,9 @@ param portalEntraApp object
 @description('Required. portal app env type internal. Default to true')
 param internal bool = true
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var customTags = {
   Location: location
   CreatedDate: createdDate
@@ -65,10 +68,10 @@ module managedEnvironment 'br/SharedDefraRegistry:app.managed-environment:0.4.10
     infrastructureSubnetId: !empty(infrastructureSubnetId) ? infrastructureSubnetId : null
     internal: internal
     location: location
-    lock: {
+    lock: resourceLockEnabled ? {
       kind: 'CanNotDelete'
       name: '${containerAppEnv.name}-CanNotDelete'
-    }
+    } : null
     workloadProfiles: !empty(workloadProfiles) ? workloadProfiles : null
     zoneRedundant: zoneRedundant
     infrastructureResourceGroupName: infrastructureResourceGroupName

--- a/infra/core/env-shared/container-apps-env/container-apps-env.bicepparam
+++ b/infra/core/env-shared/container-apps-env/container-apps-env.bicepparam
@@ -37,3 +37,5 @@ param portalEntraApp = {
 
 param internal = true 
 
+param resourceLockEnabled = #{{ resourceLockEnabled }}
+

--- a/infra/core/env-shared/flexible-server/flexible-server.bicep
+++ b/infra/core/env-shared/flexible-server/flexible-server.bicep
@@ -20,6 +20,8 @@ param diagnostics object
 param location string
 @description('Required. Environment name.')
 param environment string
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
@@ -68,7 +70,7 @@ module aadAdminUserMi 'br/SharedDefraRegistry:managed-identity.user-assigned-ide
   params: {
     name: toLower(managedIdentityName)
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
   }
 }
 

--- a/infra/core/env-shared/flexible-server/flexible-server.bicepparam
+++ b/infra/core/env-shared/flexible-server/flexible-server.bicepparam
@@ -36,3 +36,5 @@ param location = '#{{ location }}'
 param environment = '#{{ environment }}'
 
 param managedIdentityName = '#{{ fluxNotificationDBAdminManagedIdentity }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env-shared/flux-notification/managed-identity/adocallbackapp-managed-identity.bicep
+++ b/infra/core/env-shared/flux-notification/managed-identity/adocallbackapp-managed-identity.bicep
@@ -31,6 +31,9 @@ param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Application Insights object.')
 param appInsights object
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var customTags = {
   Location: location
   CreatedDate: createdDate
@@ -51,7 +54,7 @@ module managedIdentities 'br/SharedDefraRegistry:managed-identity.user-assigned-
   params: {
     name: managedIdentity.name
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     roleAssignments: roleAssignments
   }
 }

--- a/infra/core/env-shared/flux-notification/managed-identity/adocallbackapp-managed-identity.bicepparam
+++ b/infra/core/env-shared/flux-notification/managed-identity/adocallbackapp-managed-identity.bicepparam
@@ -34,3 +34,4 @@ param appInsights = {
   subscriptionId: '#{{ subscriptionId }}'
 }
 
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env-shared/flux-notification/managed-identity/fluxnotificationapp-managed-identity.bicep
+++ b/infra/core/env-shared/flux-notification/managed-identity/fluxnotificationapp-managed-identity.bicep
@@ -37,6 +37,9 @@ param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Application Insights object.')
 param appInsights object
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var customTags = {
   Location: location
   CreatedDate: createdDate
@@ -57,7 +60,7 @@ module managedIdentities 'br/SharedDefraRegistry:managed-identity.user-assigned-
   params: {
     name: managedIdentity.name
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     roleAssignments: roleAssignments
   }
 }

--- a/infra/core/env-shared/flux-notification/managed-identity/fluxnotificationapp-managed-identity.bicepparam
+++ b/infra/core/env-shared/flux-notification/managed-identity/fluxnotificationapp-managed-identity.bicepparam
@@ -37,3 +37,5 @@ param appInsights = {
   resourceGroup: '#{{ ssvSharedResourceGroup }}'
   subscriptionId: '#{{ subscriptionId }}'
 }
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env-shared/flux-notification/storage-account/storage-account.bicep
+++ b/infra/core/env-shared/flux-notification/storage-account/storage-account.bicep
@@ -29,6 +29,9 @@ param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var customTags = {
   Location: location
   CreatedDate: createdDate
@@ -56,7 +59,7 @@ module storageAccounts 'br/SharedDefraRegistry:storage.storage-account:0.5.3' = 
     name: toLower(storageAccount.name)
     tags: union(defaultTags, storageAccountTags)
     skuName: storageAccount.skuName
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     kind: kind
     networkAcls: {
       bypass: 'AzureServices'

--- a/infra/core/env-shared/flux-notification/storage-account/storage-account.bicepparam
+++ b/infra/core/env-shared/flux-notification/storage-account/storage-account.bicepparam
@@ -18,3 +18,5 @@ param environment = '#{{ environment }}'
 param subEnvironment = '#{{ subEnvironment }}'
 
 param location = '#{{ location }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env/container-registry/application-container-registry.bicep
+++ b/infra/core/env/container-registry/application-container-registry.bicep
@@ -16,7 +16,6 @@ param dataEndpointEnabled bool = false
 @description('Required. Boolean value to enable resource lock.')
 param resourceLockEnabled bool
 
-
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 

--- a/infra/core/env/container-registry/application-container-registry.bicep
+++ b/infra/core/env/container-registry/application-container-registry.bicep
@@ -13,6 +13,9 @@ param environment string
 @description('Optional. Enable a single data endpoint per region for serving data. Not relevant in case of disabled public access. Note, requires the \'acrSku\' to be \'Premium\'.')
 param dataEndpointEnabled bool = false
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
@@ -45,7 +48,7 @@ module registry 'br/SharedDefraRegistry:container-registry.registry:0.5.5' = {
   params: {
     name: containerRegistry.name
     acrSku: containerRegistry.acrSku
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     retentionPolicyDays: int(containerRegistry.retentionPolicyDays)
     softDeletePolicyDays: int(containerRegistry.softDeletePolicyDays)
     tags: union(defaultTags, containerRegistryTags)

--- a/infra/core/env/container-registry/application-container-registry.parameters.json
+++ b/infra/core/env/container-registry/application-container-registry.parameters.json
@@ -23,6 +23,9 @@
         },
         "location": {
             "value": "#{{ location }}"
+        },
+        "resourceLockEnabled": {
+            "value": #{{ resourceLockEnabled }}
         }
     }
 }

--- a/infra/core/env/front-door/adp-portal/internal/front-door-waf.parameters.json
+++ b/infra/core/env/front-door/adp-portal/internal/front-door-waf.parameters.json
@@ -170,6 +170,9 @@
     "nonProductionCustomRule": {
       "value": [        
       ]
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/front-door/baseline/external/front-door-waf.parameters.json
+++ b/infra/core/env/front-door/baseline/external/front-door-waf.parameters.json
@@ -86,6 +86,9 @@
           "action": "Block"
         }
       ]
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
+++ b/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
@@ -147,6 +147,9 @@
     "nonProductionCustomRule": {
       "value": [        
       ]
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/front-door/front-door-waf.bicep
+++ b/infra/core/env/front-door/front-door-waf.bicep
@@ -28,6 +28,9 @@ param customBlockResponseBody string
 @description('Required. Purpose Tag.')
 param purpose string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -56,7 +59,7 @@ module frontDoorWafPolicy 'br/SharedDefraRegistry:network.front-door-web-applica
   params: {
     name: wafPolicyName
     location: location
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     tags: union(tags, frontDoorWafTags)
     sku: 'Premium_AzureFrontDoor' // The Microsoft-managed WAF rule sets require the premium SKU of Front Door.
     policySettings: {

--- a/infra/core/env/front-door/front-door.bicep
+++ b/infra/core/env/front-door/front-door.bicep
@@ -16,6 +16,9 @@ param endpoints array
 @description('Optional. Array of rule set objects.')
 param ruleSets array
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -47,7 +50,7 @@ module frontDoor 'br/SharedDefraRegistry:cdn.profile:0.4.4-prerelease' = {
     afdEndpoints: map(endpoints, endpoint => {
         name: endpoint
       })
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     tags: union(tags, frontDoorTags)
     sku: sku
     ruleSets: ruleSets

--- a/infra/core/env/front-door/front-door.parameters.json
+++ b/infra/core/env/front-door/front-door.parameters.json
@@ -17,6 +17,9 @@
     "endpoints":{
       "value": #{{ noescape(afdEndpoints) }}
     },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
+    },
     "ruleSets": {
       "value": [
         {

--- a/infra/core/env/key-vault/application-keyvault-params/key-vault.bicepparam
+++ b/infra/core/env/key-vault/application-keyvault-params/key-vault.bicepparam
@@ -42,3 +42,5 @@ param roleAssignment = [
 ]
 
 param keyvaultType = 'Application'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env/key-vault/key-vault.bicep
+++ b/infra/core/env/key-vault/key-vault.bicep
@@ -17,6 +17,9 @@ param environment string
 ])
 param keyvaultType string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -67,7 +70,7 @@ module vaults 'br/SharedDefraRegistry:key-vault.vault:0.5.3' = {
     name: keyVault.name
     tags: union(defaultTags, keyVaultTags)
     vaultSku: keyVault.skuName
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     enableRbacAuthorization: true
     enableSoftDelete: bool(keyVault.enableSoftDelete)
     enablePurgeProtection: bool(keyVault.enablePurgeProtection)

--- a/infra/core/env/key-vault/platform-keyvault-params/key-vault.bicepparam
+++ b/infra/core/env/key-vault/platform-keyvault-params/key-vault.bicepparam
@@ -42,3 +42,5 @@ param roleAssignment = [
 ]
 
 param keyvaultType = 'Platform'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env/managed-cluster/aks-cluster.bicep
+++ b/infra/core/env/managed-cluster/aks-cluster.bicep
@@ -37,6 +37,9 @@ param keyVault object
 @description('Required. The parameter object for the firewall certificate key vault. The object must contain name, resourceGroup, keyVaultName and secretName.')
 param keyvaultFwCertificate object
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var commonTags = {
   Location: location
   CreatedDate: createdDate
@@ -125,7 +128,7 @@ module managedIdentity 'br/SharedDefraRegistry:managed-identity.user-assigned-id
   params: {
     name: cluster.miControlPlane
     location: location
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     tags: union(tags, tagsMi)
   }
 }
@@ -135,7 +138,7 @@ module managedIdentityAppConfig 'br/SharedDefraRegistry:managed-identity.user-as
   params: {
     name: appConfig.managedIdentityName
     location: location
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     tags: union(tags, tagsAppConfigMi)
     federatedIdentityCredentials: [
       {
@@ -156,7 +159,7 @@ module managedIdentityAso 'br/SharedDefraRegistry:managed-identity.user-assigned
     name: asoPlatformManagedIdentity
     tags: union(tags, tagsAsoMi)
     location: location
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     federatedIdentityCredentials: [
       {
         name: asoPlatformManagedIdentity
@@ -253,10 +256,10 @@ module deployAKS 'br/SharedDefraRegistry:container-service.managed-cluster:0.5.1
   params: {
     name: cluster.name
     location: location
-    lock: {
+    lock: resourceLockEnabled ? {
       kind: 'CanNotDelete'
       name: '${cluster.name}-CanNotDelete-lock'
-    }
+    } : null
     tags: union(tags, aksTags)
     kubernetesVersion: cluster.kubernetesVersion
     nodeResourceGroup: cluster.nodeResourceGroup

--- a/infra/core/env/managed-cluster/aks-cluster.bicepparam
+++ b/infra/core/env/managed-cluster/aks-cluster.bicepparam
@@ -121,3 +121,5 @@ param keyVault = {
   resourceGroup: '#{{ servicesResourceGroup }}'
   keyVaultName: '#{{ infraResourceNamePrefix }}#{{ nc_resource_keyvault }}#{{ nc_instance_regionid }}02'
 }
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env/open-ai/open-ai.bicep
+++ b/infra/core/env/open-ai/open-ai.bicep
@@ -10,6 +10,9 @@ param vnet object
 @description('Required. The parameter object for the monitoringWorkspace. The object must contain name of the name and resourceGroup.')
 param monitoringWorkspace object
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @allowed([
   'UKSouth'
 ])
@@ -55,7 +58,7 @@ module openAiUserMi 'br/SharedDefraRegistry:managed-identity.user-assigned-ident
   params: {
     name: toLower(managedIdentityName)
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
   }
 }
 

--- a/infra/core/env/open-ai/open-ai.bicep
+++ b/infra/core/env/open-ai/open-ai.bicep
@@ -68,10 +68,10 @@ module openAIDeployment 'br/avm:cognitive-services/account:0.5.3' = {
     kind: 'OpenAI'
     name: openAi.name
     location: location
-    lock: {
+    lock: resourceLockEnabled ? {
       kind: 'CanNotDelete'
       name: 'CanNotDelete'
-    }
+    } : null
     disableLocalAuth: false
     publicNetworkAccess: 'Disabled'
     networkAcls: {

--- a/infra/core/env/open-ai/open-ai.bicepparam
+++ b/infra/core/env/open-ai/open-ai.bicepparam
@@ -74,3 +74,5 @@ param deployments = [
     }
   }
 ]
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env/postgre-sql/flexible-server.bicep
+++ b/infra/core/env/postgre-sql/flexible-server.bicep
@@ -28,6 +28,9 @@ param location string
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 
@@ -104,9 +107,9 @@ module flexibleServerDeployment 'br/avm:db-for-postgre-sql/flexible-server:0.1.1
     skuName: server.skuName
     activeDirectoryAuth:'Enabled'
     passwordAuth: 'Enabled'
-    lock: {
+    lock: resourceLockEnabled ? {
       kind: 'CanNotDelete'
-    }
+    } : null
     backupRetentionDays:14
     createMode: 'Default' 
     administrators: [

--- a/infra/core/env/postgre-sql/flexible-server.bicep
+++ b/infra/core/env/postgre-sql/flexible-server.bicep
@@ -74,7 +74,7 @@ module aadAdminUserMi 'br/SharedDefraRegistry:managed-identity.user-assigned-ide
   params: {
     name: toLower(managedIdentityName)
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
   }
 }
 

--- a/infra/core/env/postgre-sql/flexible-server.bicepparam
+++ b/infra/core/env/postgre-sql/flexible-server.bicepparam
@@ -37,3 +37,5 @@ param secrets = [
   'ADO-DefraGovUK-AAD-ADP-#{{ssvEnvironment}}#{{nc_shared_instance}}'
   'ADO-DefraGovUK-AAD-ADP-#{{ssvEnvironment}}#{{nc_shared_instance}}-ClientId'
 ]
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env/private-dns-zone/aks-cluster-zone.bicep
+++ b/infra/core/env/private-dns-zone/aks-cluster-zone.bicep
@@ -13,6 +13,9 @@ param location string
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 
@@ -40,7 +43,7 @@ module privateDnsZoneModule 'br/SharedDefraRegistry:network.private-dns-zone:0.5
   name: 'aks-private-dns-zone-${deploymentDate}'
   params: {
    name: privateDnsZoneName  
-   lock: 'CanNotDelete'
+   lock: resourceLockEnabled ? 'CanNotDelete' : null
    tags: union(tags, dnsTags)
    virtualNetworkLinks: [
     {

--- a/infra/core/env/private-dns-zone/aks-cluster-zone.parameters.json
+++ b/infra/core/env/private-dns-zone/aks-cluster-zone.parameters.json
@@ -16,6 +16,9 @@
     },
     "environment": {
       "value": "#{{ environment }}"
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/private-dns-zone/flexible-server-zone.bicep
+++ b/infra/core/env/private-dns-zone/flexible-server-zone.bicep
@@ -7,6 +7,9 @@ param privateDnsZonePrefix string
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 
@@ -34,6 +37,7 @@ module privateDnsZoneModule 'br/SharedDefraRegistry:network.private-dns-zone:0.5
   name: 'postgresql-private-dns-zone-${deploymentDate}'
   params: {
    name: privateDnsZoneName  
+   lock: resourceLockEnabled ? 'CanNotDelete' : null
    tags: union(tags, dnsTags)
    virtualNetworkLinks: [
     {

--- a/infra/core/env/private-dns-zone/flexible-server-zone.parameters.json
+++ b/infra/core/env/private-dns-zone/flexible-server-zone.parameters.json
@@ -13,6 +13,9 @@
     },
     "environment": {
       "value": "#{{ environment }}"
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/public-dns-zone/dns-zone.bicep
+++ b/infra/core/env/public-dns-zone/dns-zone.bicep
@@ -11,6 +11,9 @@ param location string
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 
@@ -33,6 +36,6 @@ module publicDnsZone 'br/SharedDefraRegistry:network.dns-zone:0.5.2' = {
     location: location
     tags: tags
     enableDefaultTelemetry: true
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
   }
 }

--- a/infra/core/env/public-dns-zone/dns-zone.parameters.json
+++ b/infra/core/env/public-dns-zone/dns-zone.parameters.json
@@ -10,6 +10,9 @@
     },
     "environment": {
       "value": "#{{ environment }}"
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/redis-cache/redis-cache.bicep
+++ b/infra/core/env/redis-cache/redis-cache.bicep
@@ -19,6 +19,9 @@ param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Object array, with propterties Name, addressprefix in cidr format')
 param firewallRules array = []
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var customTags = {
   Location: location
   CreatedDate: createdDate
@@ -39,7 +42,7 @@ module redisCacheResource 'br/SharedDefraRegistry:cache.redis:0.5.10' = {
     skuName: redisCache.skuName
     capacity: int(redisCache.capacity)
     location: location
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     subnetId: resourceId(vnet.resourceGroup, 'Microsoft.Network/virtualNetworks/subnets', vnet.name, vnet.rediscachesubnet)
     tags: union(tags, redisCacheTags)
   }

--- a/infra/core/env/redis-cache/redis-cache.parameters.json
+++ b/infra/core/env/redis-cache/redis-cache.parameters.json
@@ -29,6 +29,9 @@
           "addressprefix": "#{{ subnet3AddressPrefix }}"
         }
       ]
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/search-service/search-service.bicep
+++ b/infra/core/env/search-service/search-service.bicep
@@ -27,6 +27,9 @@ param privateLinkServiceConnectionExists string = 'false'
 @description('Required. Search Service UserGroup id.')
 param searchServiceUserGroupId string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 var searchServiceName = toLower(searchService.name)
 
 var managedIdentityTags = {
@@ -55,7 +58,7 @@ module openAiUserMi 'br/SharedDefraRegistry:managed-identity.user-assigned-ident
   params: {
     name: toLower(managedIdentityName)
     tags: union(defaultTags, managedIdentityTags)
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
   }
 }
 
@@ -64,10 +67,10 @@ module searchServiceDeployment 'br/avm:search/search-service:0.4.4' = {
   params: {
     name: searchServiceName
     location: location
-    lock: {
+    lock: resourceLockEnabled ? {
       kind: 'CanNotDelete'
       name: 'CanNotDelete'
-    }
+    } : null
     publicNetworkAccess: 'disabled'
     networkRuleSet:{
       defaultAction: 'Deny'

--- a/infra/core/env/search-service/search-service.bicepparam
+++ b/infra/core/env/search-service/search-service.bicepparam
@@ -28,3 +28,5 @@ param monitoringWorkspace = {
 }
 
 param privateLinkServiceConnectionExists = '#{{ privateLinkServiceConnectionExists }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/core/env/service-bus/namespace.bicep
+++ b/infra/core/env/service-bus/namespace.bicep
@@ -10,6 +10,9 @@ param location string = resourceGroup().location
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -42,9 +45,9 @@ module serviceBusResource 'br/SharedDefraRegistry:service-bus.namespace:0.5.16' 
     skuName: serviceBus.skuName
     location: location
     minimumTlsVersion:'1.2'
-    lock: {
-      kind:'CanNotDelete'
-    }
+    lock: resourceLockEnabled ? {
+      kind: 'CanNotDelete'
+    } : null
     networkRuleSets: {
       publicNetworkAccess: 'Disabled'
     }

--- a/infra/core/env/service-bus/namespace.parameters.json
+++ b/infra/core/env/service-bus/namespace.parameters.json
@@ -21,6 +21,9 @@
     },
     "environment": {
       "value": "#{{ environment }}"
+    },
+    "resourceLockEnabled": {
+      "value": #{{ resourceLockEnabled }}
     }
   }
 }

--- a/infra/core/env/storage-account/application-storage-account.bicep
+++ b/infra/core/env/storage-account/application-storage-account.bicep
@@ -20,6 +20,9 @@ param environment string
 @description('Optional. Type of Storage Account to create for the storage account.')
 param kind string = 'StorageV2'
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -52,7 +55,7 @@ module storageAccounts 'br/SharedDefraRegistry:storage.storage-account:0.5.3' = 
     name: toLower(storageAccount.name)
     tags: union(defaultTags, storageAccountTags)
     skuName: storageAccount.skuName
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     kind: kind
     networkAcls: {
       bypass: 'AzureServices'

--- a/infra/core/env/storage-account/application-storage-account.parameters.json
+++ b/infra/core/env/storage-account/application-storage-account.parameters.json
@@ -21,6 +21,9 @@
         },
         "location": {
             "value": "#{{ location }}"
+        },
+        "resourceLockEnabled": {
+            "value": #{{ resourceLockEnabled }}
         }
     }
 }

--- a/infra/sec/application-gateway/application-gateway.bicep
+++ b/infra/sec/application-gateway/application-gateway.bicep
@@ -40,6 +40,9 @@ param frontDoorId string
 @description('Required. backends Object(backendAddressPool, backendHttpSetting, httpListener, requestRoutingRule)')
 param backends array
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -148,10 +151,10 @@ module applicationGateway 'br/SharedDefraRegistry:network.application-gateway:0.
     location: location
     sku: sku
     enableHttp2: true
-    lock: {
+    lock: resourceLockEnabled ? {
       kind: 'CanNotDelete'
       name: 'CanNotDelete'
-    }
+    } : null
     tags: union(tags, applicationGatewayTags)
     diagnosticSettings : [
       {

--- a/infra/sec/application-gateway/application-gateway.bicepparam
+++ b/infra/sec/application-gateway/application-gateway.bicepparam
@@ -930,3 +930,5 @@ param backends = [
     }
   }
 ]
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/sec/network/network-security-group.bicep
+++ b/infra/sec/network/network-security-group.bicep
@@ -5,6 +5,8 @@ param nsgList array = []
 param location string
 @description('Required. Environment name.')
 param environment string
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
 @description('Optional. Date in the format yyyy-MM-dd.')
 param createdDate string = utcNow('yyyy-MM-dd')
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
@@ -22,7 +24,7 @@ module networksecuritygroup 'br/SharedDefraRegistry:network.network-security-gro
   name: '${nsg.name}-${deploymentDate}'
   params: {
     name: nsg.name
-    lock: 'CanNotDelete'
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     location: location
     tags: union(tags, { Purpose: nsg.purpose})
     securityRules: nsg.securityRules 

--- a/infra/sec/network/network-security-group.bicepparam
+++ b/infra/sec/network/network-security-group.bicepparam
@@ -50,3 +50,5 @@ param nsgList = [
     ]
   }
 ]
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}

--- a/infra/sec/operational-insights/log-analytics-workspace.bicep
+++ b/infra/sec/operational-insights/log-analytics-workspace.bicep
@@ -7,6 +7,9 @@ param location string = resourceGroup().location
 @description('Required. Environment name.')
 param environment string
 
+@description('Required. Boolean value to enable resource lock.')
+param resourceLockEnabled bool
+
 @description('Optional. Date in the format yyyyMMdd-HHmmss.')
 param deploymentDate string = utcNow('yyyyMMdd-HHmmss')
 
@@ -30,6 +33,7 @@ module logAnalyticsWorkspaceResource 'br/SharedDefraRegistry:operational-insight
     name: logAnalytics.name
     location: location
     skuName: logAnalytics.skuName
+    lock: resourceLockEnabled ? 'CanNotDelete' : null
     tags: tags
   }
 }

--- a/infra/sec/operational-insights/log-analytics-workspace.bicepparam
+++ b/infra/sec/operational-insights/log-analytics-workspace.bicepparam
@@ -8,3 +8,5 @@ param logAnalytics = {
 param location = '#{{ location }}'
 
 param environment = '#{{ environment }}'
+
+param resourceLockEnabled = #{{ resourceLockEnabled }}


### PR DESCRIPTION
# **What this PR does / why we need it**:
This PR adds a condition around the resource 'delete' locks.  A new variable 'resourceLockEnabled' has been introduced and is set to 'false' by default and overridden to 'true' for PRE, PRD and SSV5 environments.  This will ensure lower environment resources don't have locks on them and higher environment (PRE,PRD and SSV5) resources do have locks.

This PR goes alongside PR https://github.com/DEFRA/adp-pipeline-common/pull/236

AB#341945

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=604528&view=results
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=604529&view=results
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=604531&view=results
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=604553&view=results
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=604591&view=results

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# **How does this PR make you feel**:
![gif]([https://giphy.com/)
