### PR TITLE
426953: WAF tuning for Request cookie name False positive

### DIFF
--- a/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
+++ b/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
@@ -52,8 +52,20 @@
                   "exclusions": [
                       {
                           "matchVariable": "RequestCookieNames",
-                          "selectorMatchOperator": "StartsWith",
-                          "selector": "session-auth"
+                          "selectorMatchOperator": "Contains",
+                          "selector": "session"
+                      }
+                  ]
+                },
+                {
+                  "ruleId": "942210",
+                  "enabledState": "Enabled",
+                  "action": "AnomalyScoring",
+                  "exclusions": [
+                      {
+                          "matchVariable": "RequestCookieNames",
+                          "selectorMatchOperator": "Contains",
+                          "selector": "session"
                       }
                   ]
                 }

--- a/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
+++ b/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
@@ -56,18 +56,6 @@
                           "selector": "session"
                       }
                   ]
-                },
-                {
-                  "ruleId": "942210",
-                  "enabledState": "Enabled",
-                  "action": "AnomalyScoring",
-                  "exclusions": [
-                      {
-                          "matchVariable": "RequestCookieNames",
-                          "selectorMatchOperator": "Contains",
-                          "selector": "session"
-                      }
-                  ]
                 }
               ],
               "exclusions": []
@@ -87,6 +75,24 @@
                       "action": "AnomalyScoring",
                       "exclusions": []
                   }
+              ],
+              "exclusions": []
+            },
+            {
+              "ruleGroupName": "SQLI",
+              "rules": [
+                {
+                  "ruleId": "942210",
+                  "enabledState": "Enabled",
+                  "action": "AnomalyScoring",
+                  "exclusions": [
+                      {
+                          "matchVariable": "RequestCookieNames",
+                          "selectorMatchOperator": "Contains",
+                          "selector": "session"
+                      }
+                  ]
+                }
               ],
               "exclusions": []
             }                     


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
In CoreAI service, Web Application Firewall is blocking a legitimate request and triggering below WAF rules,
MS-ThreatIntel-SQLI-99031002
SQLI-942210

And below details shows it is triggering on diffrent cookie values,
"matchVariableName":"CookieValue:coreai_mcu_frontend_session"
"matchVariableName":"CookieValue:session-auth"

As a generic fix we have tuned WAF exclusion list to exclude Request cookie name contains 'session'

Relates to ADO Work Item [AB#426953](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/426953)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
