### PR TITLE
AB441939: Adding custom WAF rule to allow Entra Authentication

### DIFF
--- a/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
+++ b/infra/core/env/front-door/baseline/internal/front-door-waf.parameters.json
@@ -177,7 +177,28 @@
             }            
           ],
           "action": "Allow"
-        }     
+        },     
+        {
+          "name": "AllowLoginMicrosoftonlineRule",
+          "enabledState": "Enabled",
+          "priority": 500,
+          "ruleType": "MatchRule",
+          "matchConditions": [
+            {
+              "matchVariable": "RequestHeader",
+              "selector": "Origin",
+              "operator": "BeginsWith",
+              "negateCondition": false,
+              "matchValue": [
+                  "https://login.microsoftonline.com"
+              ],
+              "transforms": [
+                  "Lowercase"
+              ]
+            }
+          ],
+          "action": "Allow"
+        }
       ]
     },
     "nonProductionCustomRule": {


### PR DESCRIPTION
# **What this PR does / why we need it**:
Team currently implementing Entra Authentication for their service. When the Authentication flow attempts to redirect back to the service from https://login.microsoftonline.com, WAF rule RFI 931130 (Possible Remote File Inclusion (RFI) Attack: Off-Domain Reference/Link) is triggered. 

This PR adds a custom rule for the Entra Authentication URL when used as origin as part of the redirect effectivelly overriding RFI 931130 for these conditions. The PR  matches the current custom rule added manually to the WAF custom rules list in the SND4 AFD WAF which the team has confirmed as working.

[AB#441939](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/441939)

# **Special notes for your reviewer**
https://portal.azure.com/#@Defra.onmicrosoft.com/resource/subscriptions/da83801b-f7e0-4510-9848-67d87b1009e2/resourceGroups/SNDADPINFRG4403/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/SNDADPINFWF4401/customrules

# Testing
 browsing to https://rpa-mit-manual-templates.snd4.adp.defra.gov.uk is no longer blocked by WAF rule RFI 931130

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
