### PR TITLE
Exposing local keys usage

### DIFF
--- a/infra/core/env/ai-document-intelligence/ai-document-intelligence-depolyment-1-params/ai-document-intelligence.parameters.json
+++ b/infra/core/env/ai-document-intelligence/ai-document-intelligence-depolyment-1-params/ai-document-intelligence.parameters.json
@@ -7,6 +7,7 @@
                 "name": "#{{ infraResourceNamePrefix }}#{{ nc_resource_ai_document_intelligence }}#{{ nc_instance_regionid }}01",
                 "sku": "#{{ aiDocumentIntelligenceSku }}",
                 "customSubDomainName": "#{{ infraResourceNamePrefix }}#{{ nc_resource_ai_document_intelligence }}#{{ nc_instance_regionid }}01",
+                "disableLocalAuth": false
             }    
         },
         "privateDnsZone": {

--- a/infra/core/env/ai-document-intelligence/ai-document-intelligence.bicep
+++ b/infra/core/env/ai-document-intelligence/ai-document-intelligence.bicep
@@ -57,6 +57,7 @@ module documentIntelligenceResource 'br/avm:cognitive-services/account:0.8.0' = 
     sku: aiDocumentIntelligence.sku
     customSubDomainName: aiDocumentIntelligence.customSubDomainName
     restrictOutboundNetworkAccess: restrictOutboundNetworkAccess
+    disableLocalAuth: aiDocumentIntelligence.disableLocalAuth
     managedIdentities: {
       systemAssigned: true
     }


### PR DESCRIPTION
Local keys are typically discouraged and strictly avoided where multi tenancy exists. However there are some areas of the DI offering that does not have the full RBAC support.